### PR TITLE
Add Sparkle auto-update support (v0.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.3.0
+- Add automatic updates via [Sparkle](https://sparkle-project.org). SmartClose now checks for new releases and can download/install them in the background; a "Check for Updates…" menu item and an "Automatically check for updates" setting are included. (Existing 0.2.0 users update to 0.3.0 manually once; updates are automatic from 0.3.0 onward.)
+
 ## 0.2.0
 - Add optional, experimental Cmd+W handling (off by default). SmartClose lets the app handle Cmd+W normally first, then requests a normal quit only if that closed the app's last normal window. Honors ignore/allow lists and per-app rules. (#1)
 - Fix: closing SmartClose's own window no longer quits the app — SmartClose now hard-excludes itself.

--- a/SmartClose.xcodeproj/project.pbxproj
+++ b/SmartClose.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		F015373D516A4B9181D22286 /* DecisionEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3332FEC90A4142AE834A9569 /* DecisionEngine.swift */; };
 		ACA7E700000000000000B17F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = ACA7E700000000000000F1EF /* Assets.xcassets */; };
 		5E7715C0DAB1E00000000002 /* SettingsCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7715C0DAB1E00000000001 /* SettingsCodableTests.swift */; };
+		5A8B1E00000000000000F11E /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 5A8B1E00000000000000D00D /* Sparkle */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -131,6 +132,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5A8B1E00000000000000F11E /* Sparkle in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -379,6 +381,9 @@
 			);
 			dependencies = (
 			);
+			packageProductDependencies = (
+				5A8B1E00000000000000D00D /* Sparkle */,
+			);
 			name = SmartClose;
 			productName = SmartClose;
 			productReference = 9124DFEA154B43C382B07664 /* SmartClose.app */;
@@ -433,6 +438,9 @@
 				Base,
 			);
 			mainGroup = FCBC8C9A5587447CA81A73EF;
+			packageReferences = (
+				5A8B1E00000000000000B1EF /* XCRemoteSwiftPackageReference "Sparkle" */,
+			);
 			productRefGroup = FA2727789D4B47C5BF82F011 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -536,7 +544,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = WWRZ5CG3DW;
 				ENABLE_TESTABILITY = YES;
 				INFOPLIST_FILE = "SmartCloseApp/Resources/Info-Debug.plist";
@@ -545,7 +553,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 0.2.0;
+				MARKETING_VERSION = 0.3.0;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.smartclose.app;
 				PRODUCT_NAME = SmartClose;
@@ -606,7 +614,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = WWRZ5CG3DW;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = SmartCloseApp/Resources/Info.plist;
@@ -615,7 +623,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 0.2.0;
+				MARKETING_VERSION = 0.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.smartclose.app;
 				PRODUCT_NAME = SmartClose;
 				SWIFT_VERSION = 6.0;
@@ -685,6 +693,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		5A8B1E00000000000000B1EF /* XCRemoteSwiftPackageReference "Sparkle" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/sparkle-project/Sparkle";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.5.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		5A8B1E00000000000000D00D /* Sparkle */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 5A8B1E00000000000000B1EF /* XCRemoteSwiftPackageReference "Sparkle" */;
+			productName = Sparkle;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 9C7FEB9FE5EE497183CA42C8 /* Project object */;
 }

--- a/SmartClose.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SmartClose.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "e721da7f9826abdffcb6185e886155efa2514bd6234475f1afa893e29eb258d6",
+  "pins" : [
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "d46d456107feacc80711b21847b82b07bd9fb46e",
+        "version" : "2.9.3"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/SmartCloseApp/App/AppDelegate.swift
+++ b/SmartCloseApp/App/AppDelegate.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Sparkle
 import SwiftUI
 
 @MainActor
@@ -10,15 +11,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var diagnosticsWindowController: HostingWindowController?
     private var onboardingWindowController: HostingWindowController?
 
+    private var updaterController: SPUStandardUpdaterController?
+    private var updaterBridge: UpdaterBridge!
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         let isFirstRun = !appModel.settingsStore.settings.firstRunCompleted
         Log.app.info("App did finish launching. firstRun=\(isFirstRun)")
         NSApp.setActivationPolicy(isFirstRun ? .regular : .accessory)
 
+        // Sparkle auto-updates. Starts checking on launch; shows its own first-run consent prompt.
+        let updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
+        self.updaterController = updaterController
+        updaterBridge = UpdaterBridge(updater: updaterController.updater)
+
         statusMenuController = StatusMenuController(
             settingsStore: appModel.settingsStore,
             onOpenSettings: { [weak self] in self?.openSettings() },
             onShowDiagnostics: { [weak self] in self?.openDiagnostics() },
+            onCheckForUpdates: { [weak self] in self?.updaterController?.checkForUpdates(nil) },
             onQuit: { NSApp.terminate(nil) }
         )
 
@@ -36,6 +46,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             .environmentObject(appModel.settingsStore)
             .environmentObject(appModel.permissionManager)
             .environmentObject(appModel.inputMonitoringManager)
+            .environmentObject(updaterBridge)
         if settingsWindowController == nil {
             settingsWindowController = HostingWindowController(title: "SmartClose Settings", rootView: AnyView(view))
         }
@@ -82,5 +93,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
         true
+    }
+}
+
+/// Bridges Sparkle's "automatically check for updates" preference into SwiftUI so the
+/// Settings window can toggle it. Sparkle persists the value itself.
+@MainActor
+final class UpdaterBridge: ObservableObject {
+    private let updater: SPUUpdater
+
+    init(updater: SPUUpdater) {
+        self.updater = updater
+    }
+
+    var automaticallyChecksForUpdates: Bool {
+        get { updater.automaticallyChecksForUpdates }
+        set {
+            objectWillChange.send()
+            updater.automaticallyChecksForUpdates = newValue
+        }
     }
 }

--- a/SmartCloseApp/MenuBar/StatusMenuController.swift
+++ b/SmartCloseApp/MenuBar/StatusMenuController.swift
@@ -9,6 +9,7 @@ final class StatusMenuController {
 
     private let onOpenSettings: () -> Void
     private let onShowDiagnostics: () -> Void
+    private let onCheckForUpdates: () -> Void
     private let onQuit: () -> Void
 
     private var enabledItem: NSMenuItem!
@@ -19,11 +20,13 @@ final class StatusMenuController {
         settingsStore: SettingsStore,
         onOpenSettings: @escaping () -> Void,
         onShowDiagnostics: @escaping () -> Void,
+        onCheckForUpdates: @escaping () -> Void,
         onQuit: @escaping () -> Void
     ) {
         self.settingsStore = settingsStore
         self.onOpenSettings = onOpenSettings
         self.onShowDiagnostics = onShowDiagnostics
+        self.onCheckForUpdates = onCheckForUpdates
         self.onQuit = onQuit
 
         configureStatusItem()
@@ -74,6 +77,10 @@ final class StatusMenuController {
         diagnosticsItem.target = self
         menu.addItem(diagnosticsItem)
 
+        let updatesItem = NSMenuItem(title: "Check for Updates…", action: #selector(checkForUpdates), keyEquivalent: "")
+        updatesItem.target = self
+        menu.addItem(updatesItem)
+
         menu.addItem(.separator())
 
         let quitItem = NSMenuItem(title: "Quit SmartClose", action: #selector(quitApp), keyEquivalent: "q")
@@ -113,6 +120,10 @@ final class StatusMenuController {
 
     @objc private func showDiagnostics() {
         onShowDiagnostics()
+    }
+
+    @objc private func checkForUpdates() {
+        onCheckForUpdates()
     }
 
     @objc private func quitApp() {

--- a/SmartCloseApp/Resources/Info-Debug.plist
+++ b/SmartCloseApp/Resources/Info-Debug.plist
@@ -26,5 +26,11 @@
     <false/>
     <key>NSHighResolutionCapable</key>
     <true/>
+    <key>SUEnableAutomaticChecks</key>
+    <true/>
+    <key>SUFeedURL</key>
+    <string>https://raw.githubusercontent.com/mahirozdin/SmartClose/main/appcast.xml</string>
+    <key>SUPublicEDKey</key>
+    <string>XEWYvX1cj3qpS8yul5LnA7EpgoVTR10jdwMGudeKrXQ=</string>
 </dict>
 </plist>

--- a/SmartCloseApp/Resources/Info.plist
+++ b/SmartCloseApp/Resources/Info.plist
@@ -26,5 +26,11 @@
     <true/>
     <key>NSHighResolutionCapable</key>
     <true/>
+    <key>SUEnableAutomaticChecks</key>
+    <true/>
+    <key>SUFeedURL</key>
+    <string>https://raw.githubusercontent.com/mahirozdin/SmartClose/main/appcast.xml</string>
+    <key>SUPublicEDKey</key>
+    <string>XEWYvX1cj3qpS8yul5LnA7EpgoVTR10jdwMGudeKrXQ=</string>
 </dict>
 </plist>

--- a/SmartCloseApp/Settings/SettingsView.swift
+++ b/SmartCloseApp/Settings/SettingsView.swift
@@ -5,6 +5,7 @@ struct SettingsView: View {
     @EnvironmentObject var settingsStore: SettingsStore
     @EnvironmentObject var permissionManager: PermissionManager
     @EnvironmentObject var inputMonitoringManager: InputMonitoringManager
+    @EnvironmentObject var updaterBridge: UpdaterBridge
 
     private let refreshTimer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
 
@@ -58,6 +59,10 @@ struct SettingsView: View {
                 Toggle("Enable SmartClose", isOn: settingsStore.binding(for: \.isEnabled))
                 Toggle("Launch at login", isOn: settingsStore.binding(for: \.launchAtLogin))
                 Toggle("Show menu bar icon", isOn: settingsStore.binding(for: \.showMenuBarIcon))
+                Toggle("Automatically check for updates", isOn: Binding(
+                    get: { updaterBridge.automaticallyChecksForUpdates },
+                    set: { updaterBridge.automaticallyChecksForUpdates = $0 }
+                ))
 
                 Picker("Global mode", selection: settingsStore.binding(for: \.globalMode)) {
                     ForEach(GlobalMode.allCases) { mode in

--- a/scripts/release_local.sh
+++ b/scripts/release_local.sh
@@ -111,7 +111,33 @@ xcrun stapler staple "${DMG_PATH}"
 echo "==> Writing checksums"
 shasum -a 256 "${ZIP_PATH}" "${DMG_PATH}" > "${CHECKSUM_PATH}"
 
+echo "==> Generating Sparkle appcast"
+APPCAST_PATH="${DIST_DIR}/appcast.xml"
+DOWNLOAD_URL_PREFIX="${SMARTCLOSE_DOWNLOAD_URL_PREFIX:-https://github.com/mahirozdin/SmartClose/releases/download/v${VERSION}/}"
+GENERATE_APPCAST="$(find "${ROOT_DIR}/build" -path '*sparkle/Sparkle/bin/generate_appcast' -type f 2>/dev/null | head -n 1)"
+if [[ -z "${GENERATE_APPCAST}" ]]; then
+  echo "warning: generate_appcast not found under ${ROOT_DIR}/build. Run 'xcodebuild -resolvePackageDependencies' first; skipping appcast." >&2
+else
+  # generate_appcast signs with the EdDSA private key in your login keychain and writes
+  # appcast.xml whose enclosure URL points at the release asset. Feed it only the ZIP so
+  # the DMG in DIST_DIR is not turned into a second update entry.
+  APPCAST_SRC="$(mktemp -d "${TMPDIR:-/tmp}/smartclose-appcast.XXXXXX")"
+  cp "${ZIP_PATH}" "${APPCAST_SRC}/"
+  if "${GENERATE_APPCAST}" --download-url-prefix "${DOWNLOAD_URL_PREFIX}" "${APPCAST_SRC}"; then
+    cp "${APPCAST_SRC}/appcast.xml" "${APPCAST_PATH}"
+    cp "${APPCAST_SRC}/appcast.xml" "${ROOT_DIR}/appcast.xml"
+  else
+    echo "warning: generate_appcast failed; appcast not updated." >&2
+    APPCAST_PATH=""
+  fi
+  rm -rf "${APPCAST_SRC}"
+fi
+
 echo "==> Release artifacts ready"
 echo "ZIP: ${ZIP_PATH}"
 echo "DMG: ${DMG_PATH}"
 echo "SHA256: ${CHECKSUM_PATH}"
+if [[ -n "${APPCAST_PATH}" && -f "${ROOT_DIR}/appcast.xml" ]]; then
+  echo "Appcast: ${ROOT_DIR}/appcast.xml"
+  echo "NOTE: after publishing the GitHub release assets, commit & push appcast.xml so installed apps can update."
+fi


### PR DESCRIPTION
## Summary

Adds **automatic updates** so installed copies of SmartClose update themselves when a new GitHub Release is published — using [Sparkle](https://sparkle-project.org) 2.x, the standard updater for non-App-Store macOS apps.

### What's included
- **Sparkle via SPM** (pinned `2.9.3`) linked into the app target; `Package.resolved` committed.
- **Info.plist** (Release + Debug): `SUFeedURL` → `https://raw.githubusercontent.com/mahirozdin/SmartClose/main/appcast.xml`, `SUPublicEDKey`, `SUEnableAutomaticChecks`.
- **Updater wiring**: `AppDelegate` starts an `SPUStandardUpdaterController` at launch (with Sparkle's standard first-run consent prompt). A **"Check for Updates…"** menu-bar item and an **"Automatically check for updates"** toggle in Settings (via a small `UpdaterBridge`).
- **Release pipeline**: `release_local.sh` now generates and **EdDSA-signs `appcast.xml`** after notarization, with the enclosure URL pointing at the release ZIP asset; it reminds you to commit/push `appcast.xml` after the release is published.
- Bumped to **0.3.0** (build 3); changelog updated.

### Security / key management
The EdDSA **private key lives in the maintainer's login keychain** (never committed); only the public key is in Info.plist. Losing it means no future signed updates; leaking it allows malicious updates.

### Important caveat
Auto-update only works for versions that already ship Sparkle, so **current v0.2.0 users must update to v0.3.0 manually once**. From v0.3.0 onward, updates are automatic.

## Testing
- `xcodebuild -resolvePackageDependencies` ✅ (Sparkle 2.9.3)
- Debug build ✅ — Sparkle.xcframework embedded + linked
- `xcodebuild test -only-testing:SmartCloseTests` ✅ **40 tests, 0 failures**
- End-to-end auto-update (one release updating the previous) is demonstrable once a release *after* v0.3.0 exists; the mechanism (feed fetch + "Check for Updates…") is verified against the live appcast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)