### PR TITLE
Fix: Cmd+W never quit any app (Closes #3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.3.1
+- Fix: optional Cmd+W handling never quit any app (#3). When an app's last window closed, the window count came back 0 but flagged "ambiguous", which suppressed the quit. SmartClose now counts windows just before Cmd+W and, when there was exactly one normal window that is then gone, requests the quit reliably.
+
 ## 0.3.0
 - Add automatic updates via [Sparkle](https://sparkle-project.org). SmartClose now checks for new releases and can download/install them in the background; a "Check for Updates…" menu item and an "Automatically check for updates" setting are included. (Existing 0.2.0 users update to 0.3.0 manually once; updates are automatic from 0.3.0 onward.)
 

--- a/SmartClose.xcodeproj/project.pbxproj
+++ b/SmartClose.xcodeproj/project.pbxproj
@@ -544,7 +544,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = WWRZ5CG3DW;
 				ENABLE_TESTABILITY = YES;
 				INFOPLIST_FILE = "SmartCloseApp/Resources/Info-Debug.plist";
@@ -553,7 +553,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 0.3.0;
+				MARKETING_VERSION = 0.3.1;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.smartclose.app;
 				PRODUCT_NAME = SmartClose;
@@ -614,7 +614,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = WWRZ5CG3DW;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = SmartCloseApp/Resources/Info.plist;
@@ -623,7 +623,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 0.3.0;
+				MARKETING_VERSION = 0.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.smartclose.app;
 				PRODUCT_NAME = SmartClose;
 				SWIFT_VERSION = 6.0;

--- a/SmartCloseApp/Core/DecisionEngine/DecisionEngine.swift
+++ b/SmartCloseApp/Core/DecisionEngine/DecisionEngine.swift
@@ -60,42 +60,57 @@ struct DecisionEngine {
     }
 
     /// Decision for the optional Cmd+W path. Unlike `decide`, the keystroke is never
-    /// swallowed: the app closes its own window first, then this is evaluated against the
-    /// *resulting* window count. We request a quit only once the last normal window is gone
-    /// (`count == 0`), and never while the classification is ambiguous.
-    func decideAfterCmdW(context: DecisionContext) -> DecisionResult {
-        if !context.isEnabled {
+    /// swallowed: the app closes its own window first, then this is evaluated using the window
+    /// count from *before* the keystroke and from *after*.
+    ///
+    /// We act only when there was exactly one confidently-classified normal window **before**
+    /// Cmd+W (a plausible "last window"), and the app reports zero windows **after**.
+    ///
+    /// Important: an app with no remaining windows reports `count == 0` but the window counter
+    /// also flags that result `ambiguous` ("No windows returned"). So for the *after* state we
+    /// trust the count, not the flag. (Trusting the flag was the bug behind issue #3 — the
+    /// post-close 0-window state is always ambiguous, so a quit was never requested.) The
+    /// `before` gate keeps us conservative: we only quit when we were sure there was one window.
+    func decideAfterCmdW(
+        isEnabled: Bool,
+        isPaused: Bool,
+        permissionGranted: Bool,
+        resolvedPolicy: ResolvedPolicy,
+        windowsBefore: WindowCountResult?,
+        windowsAfter: WindowCountResult?
+    ) -> DecisionResult {
+        if !isEnabled {
             return DecisionResult(action: .passThrough, reason: "SmartClose disabled")
         }
 
-        if context.isPaused {
+        if isPaused {
             return DecisionResult(action: .passThrough, reason: "Paused")
         }
 
-        if !context.permissionGranted {
+        if !permissionGranted {
             return DecisionResult(action: .passThrough, reason: "Accessibility permission missing")
         }
 
-        if context.resolvedPolicy.isExcluded || context.resolvedPolicy.behavior == .disabled {
+        if resolvedPolicy.isExcluded || resolvedPolicy.behavior == .disabled {
             return DecisionResult(action: .passThrough, reason: "Excluded by policy")
         }
 
-        if context.resolvedPolicy.behavior == .alwaysNormalClose {
+        if resolvedPolicy.behavior == .alwaysNormalClose {
             return DecisionResult(action: .passThrough, reason: "Always normal close policy")
         }
 
-        guard let windowCount = context.windowCount else {
+        guard let before = windowsBefore, before.count == 1, !before.ambiguous else {
+            return DecisionResult(action: .passThrough, reason: "Not a single normal window before Cmd+W")
+        }
+
+        guard let after = windowsAfter else {
             return DecisionResult(action: .passThrough, reason: "Window count unavailable")
         }
 
-        if windowCount.ambiguous {
-            return DecisionResult(action: .passThrough, reason: "Ambiguous window classification")
-        }
-
-        if windowCount.count == 0 {
+        if after.count == 0 {
             return DecisionResult(action: .requestQuit, reason: "Last window closed via Cmd+W")
         }
 
-        return DecisionResult(action: .passThrough, reason: "Windows still open")
+        return DecisionResult(action: .passThrough, reason: "Window still open after Cmd+W")
     }
 }

--- a/SmartCloseApp/Core/Interception/InterceptionController.swift
+++ b/SmartCloseApp/Core/Interception/InterceptionController.swift
@@ -190,32 +190,44 @@ final class InterceptionController: @unchecked Sendable {
         guard bundleID != selfBundleID else { return }
         guard policyResolver.cmdWEnabled(bundleID: bundleID, settings: settings) else { return }
 
+        // Count windows BEFORE the app handles Cmd+W. The keystroke has only been observed
+        // (the event tap runs before delivery), so the target window is still open here. Only
+        // arm when there is exactly one confidently-classified normal window — a plausible
+        // "last window" — otherwise Cmd+W is just closing a tab/secondary window and we leave
+        // it alone.
+        let windowsBefore = windowCountingService.countWindows(for: pid, appIsHidden: app.isHidden, settings: settings)
+        guard let windowsBefore, windowsBefore.count == 1, !windowsBefore.ambiguous else {
+            if settings.debugLoggingLevel == .verbose {
+                Log.interception.debug("Cmd+W not armed bundle=\(bundleID) before=\(windowsBefore?.count ?? -1) ambiguous=\(windowsBefore?.ambiguous ?? true)")
+            }
+            return
+        }
+
         let delay = max(0.05, settings.cmdWVerifyDelay)
         if settings.debugLoggingLevel == .info || settings.debugLoggingLevel == .verbose {
-            Log.interception.info("Cmd+W observed bundle=\(bundleID); verifying after \(delay)s")
+            Log.interception.info("Cmd+W armed bundle=\(bundleID); verifying after \(delay)s")
         }
 
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
-            self?.verifyAndMaybeQuitAfterCmdW(pid: pid, bundleID: bundleID, settings: settings)
+            self?.verifyAndMaybeQuitAfterCmdW(pid: pid, bundleID: bundleID, windowsBefore: windowsBefore, settings: settings)
         }
     }
 
-    private func verifyAndMaybeQuitAfterCmdW(pid: pid_t, bundleID: String, settings: Settings) {
+    private func verifyAndMaybeQuitAfterCmdW(pid: pid_t, bundleID: String, windowsBefore: WindowCountResult, settings: Settings) {
         guard let app = NSRunningApplication(processIdentifier: pid), !app.isTerminated else {
             // The app already quit on its own — nothing to do.
             return
         }
 
-        let windowCountResult = windowCountingService.countWindows(for: pid, appIsHidden: app.isHidden, settings: settings)
-        let context = DecisionContext(
+        let windowsAfter = windowCountingService.countWindows(for: pid, appIsHidden: app.isHidden, settings: settings)
+        let decision = decisionEngine.decideAfterCmdW(
             isEnabled: settings.isEnabled,
             isPaused: settings.isPaused,
             permissionGranted: true,
             resolvedPolicy: policyResolver.resolve(bundleID: bundleID, settings: settings),
-            windowCount: windowCountResult
+            windowsBefore: windowsBefore,
+            windowsAfter: windowsAfter
         )
-
-        let decision = decisionEngine.decideAfterCmdW(context: context)
         if settings.debugLoggingLevel == .info || settings.debugLoggingLevel == .verbose {
             Log.interception.info("Cmd+W decision action=\(decision.action.rawValue) reason=\(decision.reason) bundle=\(bundleID)")
         }
@@ -226,8 +238,8 @@ final class InterceptionController: @unchecked Sendable {
                 app: app,
                 bundleID: bundleID,
                 decision: decision,
-                windowCount: windowCountResult?.count,
-                ignoredCount: windowCountResult?.ignoredCount,
+                windowCount: windowsAfter?.count,
+                ignoredCount: windowsAfter?.ignoredCount,
                 actionTaken: success ? "Requested quit (Cmd+W)" : "Quit request failed (Cmd+W)"
             )
         } else {
@@ -235,8 +247,8 @@ final class InterceptionController: @unchecked Sendable {
                 app: app,
                 bundleID: bundleID,
                 decision: decision,
-                windowCount: windowCountResult?.count,
-                ignoredCount: windowCountResult?.ignoredCount,
+                windowCount: windowsAfter?.count,
+                ignoredCount: windowsAfter?.ignoredCount,
                 actionTaken: "Passed through (Cmd+W)"
             )
         }

--- a/SmartCloseTests/DecisionEngineTests.swift
+++ b/SmartCloseTests/DecisionEngineTests.swift
@@ -56,48 +56,65 @@ final class DecisionEngineTests: XCTestCase {
 
     // MARK: - Cmd+W path (decideAfterCmdW)
 
-    private func cmdWContext(
+    private func windowCount(_ count: Int, ambiguous: Bool = false) -> WindowCountResult {
+        WindowCountResult(count: count, ambiguous: ambiguous, ignoredCount: 0, reasons: [])
+    }
+
+    private func decideCmdW(
         isEnabled: Bool = true,
         isPaused: Bool = false,
         behavior: CloseBehavior = .smartClose,
         isExcluded: Bool = false,
-        count: Int,
-        ambiguous: Bool = false
-    ) -> DecisionContext {
-        DecisionContext(
+        before: WindowCountResult?,
+        after: WindowCountResult?
+    ) -> DecisionResult {
+        DecisionEngine().decideAfterCmdW(
             isEnabled: isEnabled,
             isPaused: isPaused,
             permissionGranted: true,
             resolvedPolicy: ResolvedPolicy(behavior: behavior, matchedRule: nil, isExcluded: isExcluded),
-            windowCount: WindowCountResult(count: count, ambiguous: ambiguous, ignoredCount: 0, reasons: [])
+            windowsBefore: before,
+            windowsAfter: after
         )
     }
 
-    func testCmdWQuitsWhenLastWindowGone() {
-        let engine = DecisionEngine()
-        let result = engine.decideAfterCmdW(context: cmdWContext(count: 0))
+    // Regression test for issue #3: an app with no windows reports count 0, but the window
+    // counter flags that result `ambiguous` ("No windows returned"). The Cmd+W path must still
+    // quit — it was passing through on the ambiguous flag, so Cmd+W never quit any app.
+    func testCmdWQuitsWhenLastWindowGoneEvenThoughAfterCountIsAmbiguous() {
+        let result = decideCmdW(before: windowCount(1), after: windowCount(0, ambiguous: true))
         XCTAssertEqual(result.action, .requestQuit)
     }
 
-    func testCmdWPassesThroughWhenWindowsRemain() {
-        // The Cmd+W path must NOT reuse the count == 1 logic of the close-button path.
-        let engine = DecisionEngine()
-        XCTAssertEqual(engine.decideAfterCmdW(context: cmdWContext(count: 1)).action, .passThrough)
-        XCTAssertEqual(engine.decideAfterCmdW(context: cmdWContext(count: 2)).action, .passThrough)
+    func testCmdWQuitsWhenLastWindowGone() {
+        XCTAssertEqual(decideCmdW(before: windowCount(1), after: windowCount(0)).action, .requestQuit)
     }
 
-    func testCmdWPassesThroughWhenAmbiguous() {
-        let engine = DecisionEngine()
-        let result = engine.decideAfterCmdW(context: cmdWContext(count: 0, ambiguous: true))
-        XCTAssertEqual(result.action, .passThrough)
+    func testCmdWPassesThroughWhenWindowStillOpen() {
+        XCTAssertEqual(decideCmdW(before: windowCount(1), after: windowCount(1)).action, .passThrough)
+        XCTAssertEqual(decideCmdW(before: windowCount(1), after: windowCount(2)).action, .passThrough)
+    }
+
+    func testCmdWNotArmedUnlessExactlyOneConfidentWindowBefore() {
+        // Multiple windows before → Cmd+W only closed a secondary window; never quit.
+        XCTAssertEqual(decideCmdW(before: windowCount(2), after: windowCount(0)).action, .passThrough)
+        // No window before → nothing to close.
+        XCTAssertEqual(decideCmdW(before: windowCount(0), after: windowCount(0)).action, .passThrough)
+        // Ambiguous before → not confident there was a single normal window.
+        XCTAssertEqual(decideCmdW(before: windowCount(1, ambiguous: true), after: windowCount(0)).action, .passThrough)
+        // Missing before.
+        XCTAssertEqual(decideCmdW(before: nil, after: windowCount(0)).action, .passThrough)
+    }
+
+    func testCmdWPassesThroughWhenAfterCountUnavailable() {
+        XCTAssertEqual(decideCmdW(before: windowCount(1), after: nil).action, .passThrough)
     }
 
     func testCmdWRespectsDisabledPausedAndPolicy() {
-        let engine = DecisionEngine()
-        XCTAssertEqual(engine.decideAfterCmdW(context: cmdWContext(isEnabled: false, count: 0)).action, .passThrough)
-        XCTAssertEqual(engine.decideAfterCmdW(context: cmdWContext(isPaused: true, count: 0)).action, .passThrough)
-        XCTAssertEqual(engine.decideAfterCmdW(context: cmdWContext(behavior: .disabled, isExcluded: true, count: 0)).action, .passThrough)
-        XCTAssertEqual(engine.decideAfterCmdW(context: cmdWContext(behavior: .alwaysNormalClose, count: 0)).action, .passThrough)
+        XCTAssertEqual(decideCmdW(isEnabled: false, before: windowCount(1), after: windowCount(0)).action, .passThrough)
+        XCTAssertEqual(decideCmdW(isPaused: true, before: windowCount(1), after: windowCount(0)).action, .passThrough)
+        XCTAssertEqual(decideCmdW(behavior: .disabled, isExcluded: true, before: windowCount(1), after: windowCount(0)).action, .passThrough)
+        XCTAssertEqual(decideCmdW(behavior: .alwaysNormalClose, before: windowCount(1), after: windowCount(0)).action, .passThrough)
     }
 }
 

--- a/SmartCloseTests/WindowCountingServiceTests.swift
+++ b/SmartCloseTests/WindowCountingServiceTests.swift
@@ -59,4 +59,46 @@ final class WindowCountingServiceTests: XCTestCase {
         XCTAssertEqual(result?.count, 2)
         XCTAssertFalse(result?.ambiguous ?? true)
     }
+
+    // Integration regression for issue #3: when a single-window app empties out, the real
+    // WindowCountingService yields before = {count 1, not ambiguous} and after =
+    // {count 0, ambiguous} ("No windows returned"). decideAfterCmdW must request a quit —
+    // previously it bailed on the ambiguous flag, so Cmd+W never quit any app.
+    func testCmdWDecisionQuitsWhenRealCountingServiceReportsAppEmptied() {
+        let classifier = WindowClassifier()
+        func count(_ windows: [WindowInfo]) -> WindowCountResult? {
+            let ax = MockAXInspector()
+            ax.windowInfosToReturn = windows
+            return WindowCountingService(
+                axInspector: ax,
+                classifier: classifier,
+                windowServerInspector: MockWindowServerInspector()
+            ).countWindows(for: 1, appIsHidden: false, settings: .default)
+        }
+
+        let normalWindow = WindowInfo(
+            role: kAXWindowRole as String,
+            subrole: kAXStandardWindowSubrole as String,
+            isMinimized: false,
+            isVisible: true,
+            title: "Doc"
+        )
+        let before = count([normalWindow])
+        let after = count([])
+
+        XCTAssertEqual(before?.count, 1)
+        XCTAssertEqual(before?.ambiguous, false)
+        XCTAssertEqual(after?.count, 0)
+        XCTAssertEqual(after?.ambiguous, true)
+
+        let decision = DecisionEngine().decideAfterCmdW(
+            isEnabled: true,
+            isPaused: false,
+            permissionGranted: true,
+            resolvedPolicy: ResolvedPolicy(behavior: .smartClose, matchedRule: nil, isExcluded: false),
+            windowsBefore: before,
+            windowsAfter: after
+        )
+        XCTAssertEqual(decision.action, .requestQuit)
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #3 (reported by @sohate): with Cmd+W handling enabled, Cmd+W never quit any app — even single-window apps in the allow list.

## Root cause
The Cmd+W path requested a quit only when the post-close window count was `count == 0 && !ambiguous`. But when an app's last window closes, it has **zero** windows, and `WindowCountingService` reports that as `{count: 0, ambiguous: true}` — the `windows.isEmpty` → *"No windows returned"* branch, and the Quartz fallback also returns `nil` for a window-less app. So the `ambiguous` guard tripped on **every** Cmd+W and the quit was never requested.

This is exactly what the reporter's diagnostics show: *"CotEditor – passThrough – Ambiguous window classification"* after each Cmd+W. The **red close button** was unaffected because it acts at `count == 1` (before the window closes), where classification is confident.

## Fix
- Count windows **just before** Cmd+W is delivered (the event tap runs before delivery, so the target window is still open), and **arm only when there is exactly one confidently-classified normal window** — a real "last window".
- After the verify delay, request the quit when the app reports **zero** windows, trusting the *count* (not the ambiguous flag) for the after-state. The confident before-count keeps this conservative (we won't quit apps that already had 0 or multiple windows, or where Cmd+W just closed a tab).

`decideAfterCmdW` now takes `windowsBefore` + `windowsAfter`.

## Testing
- `xcodebuild test -only-testing:SmartCloseTests` ✅ **43 tests, 0 failures**
- New unit tests cover the before/after matrix, including a **regression test** for the exact failure (after = `{count 0, ambiguous}` → now `requestQuit`).
- New **integration test** drives the decision with the **real `WindowCountingService`** output for an app that empties from one window to none — proving the two components that caused the bug now cooperate to quit.

Bumped to **0.3.1** (build 4). Since 0.3.0 ships Sparkle, 0.3.0 users will receive 0.3.1 automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)