### PR TITLE
Fix: closing an auxiliary window (Find & Replace) quits the whole app (Closes #6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.3.2
+- Fix: closing an app's auxiliary window quit the whole app (#6). Clicking the red close button on a non-standard window — e.g. CotEditor's Find & Replace panel, a dialog, or a floating inspector — was treated as closing the last window and quit the app, even with the main window still open. SmartClose now only quits when the window you close is itself a standard window.
+
 ## 0.3.1
 - Fix: optional Cmd+W handling never quit any app (#3). When an app's last window closed, the window count came back 0 but flagged "ambiguous", which suppressed the quit. SmartClose now counts windows just before Cmd+W and, when there was exactly one normal window that is then gone, requests the quit reliably.
 

--- a/SmartClose.xcodeproj/project.pbxproj
+++ b/SmartClose.xcodeproj/project.pbxproj
@@ -544,7 +544,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = WWRZ5CG3DW;
 				ENABLE_TESTABILITY = YES;
 				INFOPLIST_FILE = "SmartCloseApp/Resources/Info-Debug.plist";
@@ -553,7 +553,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 0.3.1;
+				MARKETING_VERSION = 0.3.2;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.smartclose.app;
 				PRODUCT_NAME = SmartClose;
@@ -614,7 +614,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = WWRZ5CG3DW;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = SmartCloseApp/Resources/Info.plist;
@@ -623,7 +623,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 0.3.1;
+				MARKETING_VERSION = 0.3.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.smartclose.app;
 				PRODUCT_NAME = SmartClose;
 				SWIFT_VERSION = 6.0;

--- a/SmartCloseApp/App/AppModel.swift
+++ b/SmartCloseApp/App/AppModel.swift
@@ -36,6 +36,7 @@ final class AppModel {
             eventMonitor: eventMonitor,
             axInspector: axInspector,
             windowCountingService: windowCounter,
+            windowClassifier: windowClassifier,
             decisionEngine: decisionEngine,
             policyResolver: policyResolver,
             actionExecutor: actionExecutor,

--- a/SmartCloseApp/Core/DecisionEngine/DecisionEngine.swift
+++ b/SmartCloseApp/Core/DecisionEngine/DecisionEngine.swift
@@ -11,6 +11,9 @@ struct DecisionContext {
     let permissionGranted: Bool
     let resolvedPolicy: ResolvedPolicy
     let windowCount: WindowCountResult?
+    /// Whether the window whose close button was clicked is itself a standard window.
+    /// Closing an auxiliary panel (e.g. Find & Replace) must never quit the app.
+    let closedWindowIsStandard: Bool
 }
 
 struct DecisionResult: Codable {
@@ -38,6 +41,13 @@ struct DecisionEngine {
 
         if context.resolvedPolicy.behavior == .alwaysNormalClose {
             return DecisionResult(action: .passThrough, reason: "Always normal close policy")
+        }
+
+        // Only the close button of a standard window can quit the app. Closing an auxiliary
+        // window (Find & Replace, a dialog, a floating inspector, …) leaves the real windows
+        // open, so it must pass through even if exactly one normal window exists (issue #6).
+        if !context.closedWindowIsStandard {
+            return DecisionResult(action: .passThrough, reason: "Closed window is not a standard window")
         }
 
         guard let windowCount = context.windowCount else {

--- a/SmartCloseApp/Core/Interception/InterceptionController.swift
+++ b/SmartCloseApp/Core/Interception/InterceptionController.swift
@@ -10,6 +10,7 @@ final class InterceptionController: @unchecked Sendable {
     private let eventMonitor: EventMonitor
     private let axInspector: AXInspecting
     private let windowCountingService: WindowCountingService
+    private let windowClassifier: WindowClassifier
     private let decisionEngine: DecisionEngine
     private let policyResolver: AppPolicyResolver
     private let actionExecutor: ActionExecutor
@@ -21,6 +22,7 @@ final class InterceptionController: @unchecked Sendable {
         eventMonitor: EventMonitor,
         axInspector: AXInspecting,
         windowCountingService: WindowCountingService,
+        windowClassifier: WindowClassifier,
         decisionEngine: DecisionEngine,
         policyResolver: AppPolicyResolver,
         actionExecutor: ActionExecutor,
@@ -30,6 +32,7 @@ final class InterceptionController: @unchecked Sendable {
         self.eventMonitor = eventMonitor
         self.axInspector = axInspector
         self.windowCountingService = windowCountingService
+        self.windowClassifier = windowClassifier
         self.decisionEngine = decisionEngine
         self.policyResolver = policyResolver
         self.actionExecutor = actionExecutor
@@ -125,12 +128,21 @@ final class InterceptionController: @unchecked Sendable {
             }
         }
 
+        let closedWindowIsStandard = windowClassifier.isStandardWindow(
+            role: axInspector.role(of: window),
+            subrole: axInspector.subrole(of: window)
+        )
+        if logVerbose {
+            Log.interception.debug("Closed window standard=\(closedWindowIsStandard)")
+        }
+
         let context = DecisionContext(
             isEnabled: settings.isEnabled,
             isPaused: settings.isPaused,
             permissionGranted: true,
             resolvedPolicy: resolved,
-            windowCount: windowCountResult
+            windowCount: windowCountResult,
+            closedWindowIsStandard: closedWindowIsStandard
         )
 
         let decision = decisionEngine.decide(context: context)

--- a/SmartCloseApp/Core/WindowModel/WindowClassifier.swift
+++ b/SmartCloseApp/Core/WindowModel/WindowClassifier.swift
@@ -14,6 +14,16 @@ final class WindowClassifier {
         AXSubrole.sheet
     ]
 
+    /// Whether a window with this role/subrole counts as a "normal" standard window for the
+    /// last-window decision. Auxiliary windows — dialogs, the Find/Replace panel, floating
+    /// inspectors, sheets, popovers — are not standard windows, so closing one must never quit
+    /// the app (issue #6).
+    func isStandardWindow(role: String?, subrole: String?) -> Bool {
+        guard let role, role == kAXWindowRole as String else { return false }
+        guard let subrole else { return false }
+        return normalSubroles.contains(subrole)
+    }
+
     func classify(windows: [WindowInfo], appIsHidden: Bool, settings: Settings) -> WindowCountResult {
         var countable = 0
         var ignored = 0

--- a/SmartCloseTests/DecisionEngineTests.swift
+++ b/SmartCloseTests/DecisionEngineTests.swift
@@ -2,56 +2,50 @@ import XCTest
 @testable import SmartClose
 
 final class DecisionEngineTests: XCTestCase {
-    func testLastWindowRequestsQuit() {
-        let engine = DecisionEngine()
-        let context = DecisionContext(
-            isEnabled: true,
-            isPaused: false,
+    private func decideClose(
+        isEnabled: Bool = true,
+        isPaused: Bool = false,
+        behavior: CloseBehavior = .smartClose,
+        isExcluded: Bool = false,
+        count: Int,
+        ambiguous: Bool = false,
+        closedWindowIsStandard: Bool = true
+    ) -> DecisionResult {
+        DecisionEngine().decide(context: DecisionContext(
+            isEnabled: isEnabled,
+            isPaused: isPaused,
             permissionGranted: true,
-            resolvedPolicy: ResolvedPolicy(behavior: .smartClose, matchedRule: nil, isExcluded: false),
-            windowCount: WindowCountResult(count: 1, ambiguous: false, ignoredCount: 0, reasons: [])
-        )
-        let result = engine.decide(context: context)
-        XCTAssertEqual(result.action, .requestQuit)
+            resolvedPolicy: ResolvedPolicy(behavior: behavior, matchedRule: nil, isExcluded: isExcluded),
+            windowCount: WindowCountResult(count: count, ambiguous: ambiguous, ignoredCount: 0, reasons: []),
+            closedWindowIsStandard: closedWindowIsStandard
+        ))
+    }
+
+    func testLastWindowRequestsQuit() {
+        XCTAssertEqual(decideClose(count: 1).action, .requestQuit)
     }
 
     func testMultipleWindowsPassThrough() {
-        let engine = DecisionEngine()
-        let context = DecisionContext(
-            isEnabled: true,
-            isPaused: false,
-            permissionGranted: true,
-            resolvedPolicy: ResolvedPolicy(behavior: .smartClose, matchedRule: nil, isExcluded: false),
-            windowCount: WindowCountResult(count: 2, ambiguous: false, ignoredCount: 0, reasons: [])
-        )
-        let result = engine.decide(context: context)
-        XCTAssertEqual(result.action, .passThrough)
+        XCTAssertEqual(decideClose(count: 2).action, .passThrough)
     }
 
     func testDisabledPassThrough() {
-        let engine = DecisionEngine()
-        let context = DecisionContext(
-            isEnabled: false,
-            isPaused: false,
-            permissionGranted: true,
-            resolvedPolicy: ResolvedPolicy(behavior: .smartClose, matchedRule: nil, isExcluded: false),
-            windowCount: WindowCountResult(count: 1, ambiguous: false, ignoredCount: 0, reasons: [])
-        )
-        let result = engine.decide(context: context)
-        XCTAssertEqual(result.action, .passThrough)
+        XCTAssertEqual(decideClose(isEnabled: false, count: 1).action, .passThrough)
     }
 
     func testAmbiguousPassThrough() {
-        let engine = DecisionEngine()
-        let context = DecisionContext(
-            isEnabled: true,
-            isPaused: false,
-            permissionGranted: true,
-            resolvedPolicy: ResolvedPolicy(behavior: .smartClose, matchedRule: nil, isExcluded: false),
-            windowCount: WindowCountResult(count: 1, ambiguous: true, ignoredCount: 0, reasons: ["Missing role"])
-        )
-        let result = engine.decide(context: context)
-        XCTAssertEqual(result.action, .passThrough)
+        XCTAssertEqual(decideClose(count: 1, ambiguous: true).action, .passThrough)
+    }
+
+    // Regression for issue #6: clicking the close button of an auxiliary window (Find &
+    // Replace, a dialog, a floating panel) must never quit, even when the app has exactly one
+    // standard window remaining.
+    func testNonStandardClosedWindowPassesThroughEvenAtLastWindow() {
+        XCTAssertEqual(decideClose(count: 1, closedWindowIsStandard: false).action, .passThrough)
+    }
+
+    func testStandardClosedWindowQuitsAtLastWindow() {
+        XCTAssertEqual(decideClose(count: 1, closedWindowIsStandard: true).action, .requestQuit)
     }
 
     // MARK: - Cmd+W path (decideAfterCmdW)

--- a/SmartCloseTests/WindowClassifierTests.swift
+++ b/SmartCloseTests/WindowClassifierTests.swift
@@ -62,4 +62,26 @@ final class WindowClassifierTests: XCTestCase {
         let result = classifier.classify(windows: [window], appIsHidden: false, settings: settings)
         XCTAssertTrue(result.ambiguous)
     }
+
+    // MARK: - isStandardWindow (issue #6: closing an auxiliary window must not quit)
+
+    func testIsStandardWindowTrueForStandardWindow() {
+        let classifier = WindowClassifier()
+        XCTAssertTrue(classifier.isStandardWindow(role: kAXWindowRole as String, subrole: kAXStandardWindowSubrole as String))
+    }
+
+    func testIsStandardWindowFalseForAuxiliaryWindows() {
+        let classifier = WindowClassifier()
+        XCTAssertFalse(classifier.isStandardWindow(role: kAXWindowRole as String, subrole: kAXDialogSubrole as String))
+        XCTAssertFalse(classifier.isStandardWindow(role: kAXWindowRole as String, subrole: kAXFloatingWindowSubrole as String))
+        XCTAssertFalse(classifier.isStandardWindow(role: kAXWindowRole as String, subrole: kAXSystemDialogSubrole as String))
+        XCTAssertFalse(classifier.isStandardWindow(role: kAXWindowRole as String, subrole: "AXUnknown"))
+    }
+
+    func testIsStandardWindowFalseForMissingOrNonWindowRole() {
+        let classifier = WindowClassifier()
+        XCTAssertFalse(classifier.isStandardWindow(role: nil, subrole: kAXStandardWindowSubrole as String))
+        XCTAssertFalse(classifier.isStandardWindow(role: kAXWindowRole as String, subrole: nil))
+        XCTAssertFalse(classifier.isStandardWindow(role: "AXButton", subrole: kAXStandardWindowSubrole as String))
+    }
 }


### PR DESCRIPTION
## Summary
Fixes #6 (reported by @sohate with a video): closing CotEditor's **Find & Replace** window quit the entire app, even with the main document window still open.

## Root cause
The reporter's diagnostics show it precisely: **`Window count: 1, Ignored windows: 1, Decision: requestQuit, Reason: "Last normal window"`**.

The Find & Replace panel is (correctly) an auxiliary window, so it's excluded from the normal-window count — leaving `count == 1` (the main document). But the close-button path only asked *"how many normal windows does the app have?"* and never checked that the window **being closed** was itself a normal window. So clicking the panel's close button, while exactly one standard window existed elsewhere, was treated as closing the last window → quit.

## Fix
Classify the **clicked** window and only apply quit-on-last-window when it is a standard window. Closing a dialog / floating panel / Find bar / sheet now always passes through.

- `WindowClassifier.isStandardWindow(role:subrole:)` — single source of truth for "normal window".
- `DecisionContext.closedWindowIsStandard` threaded from `InterceptionController` (reads the clicked window's role/subrole).
- `decide()` passes through when the closed window isn't standard.

## Testing
- `xcodebuild test -only-testing:SmartCloseTests` ✅ **48 tests, 0 failures**
- New: pass-through for a non-standard closed window even at the last window (regression for #6); `isStandardWindow` coverage (standard → true; dialog/floating/system-dialog/unknown/non-window/nil → false).

Bumped to **0.3.2** (build 5). 0.3.x users get it via auto-update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)