### PR TITLE
Fix Cmd+W verification retry on macOS 26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.3.3
+- Fix: Cmd+W handling could pass through on macOS 26 when the just-closed last window was still reported briefly by the accessibility/window APIs (#8). SmartClose now retries the post-Cmd+W verification for a short bounded window and records the before/after samples in diagnostics.
+
 ## 0.3.2
 - Fix: closing an app's auxiliary window quit the whole app (#6). Clicking the red close button on a non-standard window — e.g. CotEditor's Find & Replace panel, a dialog, or a floating inspector — was treated as closing the last window and quit the app, even with the main window still open. SmartClose now only quits when the window you close is itself a standard window.
 

--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ Behavior → Handle Cmd+W (experimental)**.
 It is intentionally conservative and **off by default**, because `Cmd+W` also
 closes tabs, documents, and editor panes in many apps. When enabled, SmartClose
 never intercepts the keystroke: it lets the app handle `Cmd+W` normally first,
-then re-checks the window count a moment later and requests a normal quit only if
-that actually closed the app's last normal window. It honors the ignore/allow
-lists and per-app rules, and never acts on SmartClose itself.
+then re-checks the window count over a short bounded retry window and requests a
+normal quit only if that actually closed the app's last normal window. It honors
+the ignore/allow lists and per-app rules, and never acts on SmartClose itself.
 
 ## Permissions
 

--- a/SmartClose.xcodeproj/project.pbxproj
+++ b/SmartClose.xcodeproj/project.pbxproj
@@ -544,7 +544,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_TEAM = WWRZ5CG3DW;
 				ENABLE_TESTABILITY = YES;
 				INFOPLIST_FILE = "SmartCloseApp/Resources/Info-Debug.plist";
@@ -553,7 +553,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 0.3.2;
+				MARKETING_VERSION = 0.3.3;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.smartclose.app;
 				PRODUCT_NAME = SmartClose;
@@ -614,7 +614,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_TEAM = WWRZ5CG3DW;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = SmartCloseApp/Resources/Info.plist;
@@ -623,7 +623,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 0.3.2;
+				MARKETING_VERSION = 0.3.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.smartclose.app;
 				PRODUCT_NAME = SmartClose;
 				SWIFT_VERSION = 6.0;

--- a/SmartCloseApp/Core/Interception/InterceptionController.swift
+++ b/SmartCloseApp/Core/Interception/InterceptionController.swift
@@ -2,6 +2,28 @@ import AppKit
 import ApplicationServices
 import Foundation
 
+struct CmdWVerificationPolicy: Equatable {
+    let initialDelay: TimeInterval
+    let retryInterval: TimeInterval
+    let maxDuration: TimeInterval
+
+    init(
+        configuredInitialDelay: TimeInterval,
+        retryInterval: TimeInterval = 0.2,
+        maxDuration: TimeInterval = 1.0
+    ) {
+        initialDelay = max(0.05, configuredInitialDelay)
+        self.retryInterval = max(0.05, retryInterval)
+        self.maxDuration = max(initialDelay, maxDuration)
+    }
+
+    func nextDelay(afterElapsed elapsed: TimeInterval, latestResult: WindowCountResult?) -> TimeInterval? {
+        guard latestResult?.count != 0 else { return nil }
+        guard elapsed < maxDuration else { return nil }
+        return min(retryInterval, maxDuration - elapsed)
+    }
+}
+
 // All stored dependencies are immutable `let` references already shared with the event-tap
 // thread; the controller holds no mutable state of its own, so it is safe to hand to the
 // main-actor verification closure used by the optional Cmd+W path.
@@ -215,23 +237,41 @@ final class InterceptionController: @unchecked Sendable {
             return
         }
 
-        let delay = max(0.05, settings.cmdWVerifyDelay)
+        let verificationPolicy = CmdWVerificationPolicy(configuredInitialDelay: settings.cmdWVerifyDelay)
+        let delay = verificationPolicy.initialDelay
         if settings.debugLoggingLevel == .info || settings.debugLoggingLevel == .verbose {
             Log.interception.info("Cmd+W armed bundle=\(bundleID); verifying after \(delay)s")
         }
 
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
-            self?.verifyAndMaybeQuitAfterCmdW(pid: pid, bundleID: bundleID, windowsBefore: windowsBefore, settings: settings)
+            self?.verifyAndMaybeQuitAfterCmdW(
+                pid: pid,
+                bundleID: bundleID,
+                windowsBefore: windowsBefore,
+                settings: settings,
+                verificationPolicy: verificationPolicy,
+                elapsed: delay,
+                samples: []
+            )
         }
     }
 
-    private func verifyAndMaybeQuitAfterCmdW(pid: pid_t, bundleID: String, windowsBefore: WindowCountResult, settings: Settings) {
+    private func verifyAndMaybeQuitAfterCmdW(
+        pid: pid_t,
+        bundleID: String,
+        windowsBefore: WindowCountResult,
+        settings: Settings,
+        verificationPolicy: CmdWVerificationPolicy,
+        elapsed: TimeInterval,
+        samples: [WindowCountResult?]
+    ) {
         guard let app = NSRunningApplication(processIdentifier: pid), !app.isTerminated else {
             // The app already quit on its own — nothing to do.
             return
         }
 
         let windowsAfter = windowCountingService.countWindows(for: pid, appIsHidden: app.isHidden, settings: settings)
+        let samples = samples + [windowsAfter]
         let decision = decisionEngine.decideAfterCmdW(
             isEnabled: settings.isEnabled,
             isPaused: settings.isPaused,
@@ -252,8 +292,22 @@ final class InterceptionController: @unchecked Sendable {
                 decision: decision,
                 windowCount: windowsAfter?.count,
                 ignoredCount: windowsAfter?.ignoredCount,
-                actionTaken: success ? "Requested quit (Cmd+W)" : "Quit request failed (Cmd+W)"
+                actionTaken: success ? "Requested quit (Cmd+W)" : "Quit request failed (Cmd+W)",
+                details: cmdWVerificationDetails(windowsBefore: windowsBefore, samples: samples, elapsed: elapsed)
             )
+        } else if let nextDelay = verificationPolicy.nextDelay(afterElapsed: elapsed, latestResult: windowsAfter) {
+            let nextElapsed = elapsed + nextDelay
+            DispatchQueue.main.asyncAfter(deadline: .now() + nextDelay) { [weak self] in
+                self?.verifyAndMaybeQuitAfterCmdW(
+                    pid: pid,
+                    bundleID: bundleID,
+                    windowsBefore: windowsBefore,
+                    settings: settings,
+                    verificationPolicy: verificationPolicy,
+                    elapsed: nextElapsed,
+                    samples: samples
+                )
+            }
         } else {
             logDecision(
                 app: app,
@@ -261,9 +315,37 @@ final class InterceptionController: @unchecked Sendable {
                 decision: decision,
                 windowCount: windowsAfter?.count,
                 ignoredCount: windowsAfter?.ignoredCount,
-                actionTaken: "Passed through (Cmd+W)"
+                actionTaken: "Passed through (Cmd+W)",
+                details: cmdWVerificationDetails(windowsBefore: windowsBefore, samples: samples, elapsed: elapsed)
             )
         }
+    }
+
+    private func cmdWVerificationDetails(
+        windowsBefore: WindowCountResult,
+        samples: [WindowCountResult?],
+        elapsed: TimeInterval
+    ) -> String {
+        let before = windowCountSummary(windowsBefore)
+        let after = samples.enumerated()
+            .map { index, result in
+                "after[\(index + 1)]=\(windowCountSummary(result))"
+            }
+            .joined(separator: "; ")
+        return "Cmd+W verify before=\(before); \(after); elapsed=\(String(format: "%.2f", elapsed))s"
+    }
+
+    private func windowCountSummary(_ result: WindowCountResult?) -> String {
+        guard let result else { return "unavailable" }
+        var parts = [
+            "count \(result.count)",
+            "ignored \(result.ignoredCount)",
+            "ambiguous \(result.ambiguous)"
+        ]
+        if !result.reasons.isEmpty {
+            parts.append("reasons \(result.reasons.joined(separator: ", "))")
+        }
+        return parts.joined(separator: ", ")
     }
 
     private func isCloseButton(element: AXUIElement) -> Bool {
@@ -280,7 +362,8 @@ final class InterceptionController: @unchecked Sendable {
         decision: DecisionResult,
         windowCount: Int?,
         ignoredCount: Int?,
-        actionTaken: String
+        actionTaken: String,
+        details: String? = nil
     ) {
         guard settingsStore.settings.diagnosticsEnabled else { return }
         let event = DiagnosticEvent(
@@ -292,7 +375,8 @@ final class InterceptionController: @unchecked Sendable {
             ignoredCount: ignoredCount,
             decision: decision.action,
             reason: decision.reason,
-            actionTaken: actionTaken
+            actionTaken: actionTaken,
+            details: details
         )
         let store = diagnosticsStore
         Task { @MainActor in

--- a/SmartCloseApp/Diagnostics/DiagnosticsStore.swift
+++ b/SmartCloseApp/Diagnostics/DiagnosticsStore.swift
@@ -11,6 +11,7 @@ struct DiagnosticEvent: Identifiable, Codable {
     let decision: DecisionAction
     let reason: String
     let actionTaken: String
+    let details: String?
 }
 
 enum EventMonitorRuntimeState: String, Equatable {

--- a/SmartCloseApp/Diagnostics/DiagnosticsView.swift
+++ b/SmartCloseApp/Diagnostics/DiagnosticsView.swift
@@ -59,6 +59,12 @@ struct DiagnosticsView: View {
                     Text("Decision: \(latest.decision.rawValue)")
                     Text("Reason: \(latest.reason)")
                     Text("Action taken: \(latest.actionTaken)")
+                    if let details = latest.details, !details.isEmpty {
+                        Text(details)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+                    }
                 }
                 .font(.subheadline)
             } else {
@@ -75,6 +81,12 @@ struct DiagnosticsView: View {
                         .font(.headline)
                     Text(event.reason)
                         .font(.subheadline)
+                    if let details = event.details, !details.isEmpty {
+                        Text(details)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+                    }
                     Text(event.timestamp, style: .time)
                         .font(.caption)
                 }

--- a/SmartCloseTests/DecisionEngineTests.swift
+++ b/SmartCloseTests/DecisionEngineTests.swift
@@ -89,6 +89,41 @@ final class DecisionEngineTests: XCTestCase {
         XCTAssertEqual(decideCmdW(before: windowCount(1), after: windowCount(2)).action, .passThrough)
     }
 
+    func testCmdWCanQuitAfterTransientNonZeroRetrySample() {
+        let firstSample = decideCmdW(before: windowCount(1), after: windowCount(1))
+        let secondSample = decideCmdW(before: windowCount(1), after: windowCount(0))
+
+        XCTAssertEqual(firstSample.action, .passThrough)
+        XCTAssertEqual(firstSample.reason, "Window still open after Cmd+W")
+        XCTAssertEqual(secondSample.action, .requestQuit)
+    }
+
+    func testCmdWVerificationPolicyRetriesUntilClosedOrTimedOut() {
+        let policy = CmdWVerificationPolicy(
+            configuredInitialDelay: 0.25,
+            retryInterval: 0.2,
+            maxDuration: 1.0
+        )
+
+        XCTAssertEqual(policy.initialDelay, 0.25, accuracy: 0.0001)
+        XCTAssertEqual(policy.maxDuration, 1.0, accuracy: 0.0001)
+        XCTAssertEqual(policy.nextDelay(afterElapsed: 0.25, latestResult: windowCount(1)) ?? -1, 0.2, accuracy: 0.0001)
+        XCTAssertNil(policy.nextDelay(afterElapsed: 0.45, latestResult: windowCount(0)))
+        XCTAssertNil(policy.nextDelay(afterElapsed: 1.0, latestResult: windowCount(1)))
+    }
+
+    func testCmdWVerificationPolicyKeepsCustomInitialDelayInsideTimeout() {
+        let policy = CmdWVerificationPolicy(
+            configuredInitialDelay: 1.5,
+            retryInterval: 0.2,
+            maxDuration: 1.0
+        )
+
+        XCTAssertEqual(policy.initialDelay, 1.5, accuracy: 0.0001)
+        XCTAssertEqual(policy.maxDuration, 1.5, accuracy: 0.0001)
+        XCTAssertNil(policy.nextDelay(afterElapsed: 1.5, latestResult: windowCount(1)))
+    }
+
     func testCmdWNotArmedUnlessExactlyOneConfidentWindowBefore() {
         // Multiple windows before → Cmd+W only closed a secondary window; never quit.
         XCTAssertEqual(decideCmdW(before: windowCount(2), after: windowCount(0)).action, .passThrough)


### PR DESCRIPTION
## Summary
- retry the post-Cmd+W window verification for a short bounded window instead of trusting a single sample
- keep the existing safety gate: SmartClose only arms when exactly one confident normal window existed before Cmd+W
- add Cmd+W verification sample details to diagnostics
- bump the app to 0.3.3 / build 6 and document the fix

## Root cause
Issue #8 diagnostics showed SmartClose receiving Cmd+W and passing through with `Window still open after Cmd+W`. That points to the post-Cmd+W window count still reporting `1` shortly after macOS handled the shortcut, likely because macOS 26.5.1 keeps the just-closed window visible to the accessibility/window APIs for longer than the previous single 0.25s verification allowed.

## Validation
- `xcodebuild test -scheme SmartClose -destination 'platform=macOS'`
- 51 unit tests passed
- 4 UI tests passed

Refs #8