### PR TITLE
(fix) Safari false closing; unable to configure app after hiding icon; README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Each release also includes a notarized ZIP of the same app bundle and a SHA-256 
 
 ### Build from source
 
-1. Open [SmartClose.xcodeproj](/Volumes/DevSSD/HomeCache/mahirtahaozdin/Documents/NormalQuit/SmartClose.xcodeproj) in Xcode.
+1. Open [SmartClose.xcodeproj](./SmartClose.xcodeproj) in Xcode.
 2. Select the `SmartClose` scheme.
 3. Build and run.
 
@@ -79,17 +79,17 @@ the ignore/allow lists and per-app rules, and never acts on SmartClose itself.
 
 SmartClose uses macOS Accessibility APIs to detect the close action and inspect windows, plus Input Monitoring to receive the global close-button click.
 
-Detailed permission notes live in [docs/permissions.md](/Volumes/DevSSD/HomeCache/mahirtahaozdin/Documents/NormalQuit/docs/permissions.md).
+Detailed permission notes live in [docs/permissions.md](./docs/permissions.md).
 
 ## Releasing
 
-Release and notarization steps live in [docs/release.md](/Volumes/DevSSD/HomeCache/mahirtahaozdin/Documents/NormalQuit/docs/release.md).
+Release and notarization steps live in [docs/release.md](./docs/release.md).
 
 The repository includes:
 
-- [scripts/release_local.sh](/Volumes/DevSSD/HomeCache/mahirtahaozdin/Documents/NormalQuit/scripts/release_local.sh) for local signed and notarized builds
-- [scripts/create_dmg.sh](/Volumes/DevSSD/HomeCache/mahirtahaozdin/Documents/NormalQuit/scripts/create_dmg.sh) for DMG packaging
-- [release.yml](/Volumes/DevSSD/HomeCache/mahirtahaozdin/Documents/NormalQuit/.github/workflows/release.yml) for GitHub Actions releases
+- [scripts/release_local.sh](./scripts/release_local.sh) for local signed and notarized builds
+- [scripts/create_dmg.sh](./scripts/create_dmg.sh) for DMG packaging
+- [release.yml](./.github/workflows/release.yml) for GitHub Actions releases
 
 ## Known limitations
 
@@ -101,9 +101,9 @@ The repository includes:
 
 ## Documentation
 
-- [FAQ](/Volumes/DevSSD/HomeCache/mahirtahaozdin/Documents/NormalQuit/docs/faq.md)
-- [Contributing](/Volumes/DevSSD/HomeCache/mahirtahaozdin/Documents/NormalQuit/CONTRIBUTING.md)
-- [Changelog](/Volumes/DevSSD/HomeCache/mahirtahaozdin/Documents/NormalQuit/CHANGELOG.md)
+- [FAQ](./docs/faq.md)
+- [Contributing](./CONTRIBUTING.md)
+- [Changelog](./CHANGELOG.md)
 
 ## Contributors
 

--- a/SmartCloseApp/App/AppDelegate.swift
+++ b/SmartCloseApp/App/AppDelegate.swift
@@ -37,7 +37,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 Log.app.info("Opening onboarding window (first run)")
                 self?.openOnboarding()
             }
+        } else if !appModel.settingsStore.settings.showMenuBarIcon {
+            // The menubar icon is normally the only way to reach Settings in this accessory app.
+            // When a user hides it, launching the app again provides a recovery path rather than
+            // leaving the running app with no visible UI. Keep onboarding above this path so
+            // first-run users still complete setup first.
+            DispatchQueue.main.async { [weak self] in
+                Log.app.info("Opening settings window because the menu-bar icon is hidden")
+                self?.openSettings()
+            }
         }
+    }
+
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        guard !appModel.settingsStore.settings.showMenuBarIcon else {
+            return false
+        }
+
+        Log.app.info("Opening settings window after app reopen because the menu-bar icon is hidden")
+        openSettings()
+        return false
     }
 
     private func openSettings() {

--- a/SmartCloseApp/Core/WindowModel/WindowClassifier.swift
+++ b/SmartCloseApp/Core/WindowModel/WindowClassifier.swift
@@ -29,6 +29,7 @@ final class WindowClassifier {
         var ignored = 0
         var ambiguous = false
         var reasons: [String] = []
+        var hasPotentiallyOpenAuxiliaryWindow = false
 
         for window in windows {
             guard let role = window.role else {
@@ -39,6 +40,7 @@ final class WindowClassifier {
 
             if role != kAXWindowRole as String {
                 ignored += 1
+                reasons.append("Ignored non-window role: \(role)")
                 continue
             }
 
@@ -50,6 +52,12 @@ final class WindowClassifier {
 
             if ignoredSubroles.contains(subrole) {
                 ignored += 1
+                if window.isMinimized == true && !settings.countMinimizedWindows {
+                    reasons.append("Ignored minimized auxiliary subrole: \(subrole)")
+                } else {
+                    hasPotentiallyOpenAuxiliaryWindow = true
+                    reasons.append("Ignored auxiliary subrole: \(subrole)")
+                }
                 continue
             }
 
@@ -62,12 +70,14 @@ final class WindowClassifier {
 
             if appIsHidden && !settings.countHiddenWindows {
                 ignored += 1
+                reasons.append("Ignored because app is hidden")
                 continue
             }
 
             if let isMinimized = window.isMinimized {
                 if isMinimized && !settings.countMinimizedWindows {
                     ignored += 1
+                    reasons.append("Ignored minimized window")
                     continue
                 }
             } else if !settings.countMinimizedWindows {
@@ -79,6 +89,7 @@ final class WindowClassifier {
             if let isVisible = window.isVisible {
                 if !isVisible && !settings.countHiddenWindows {
                     ignored += 1
+                    reasons.append("Ignored hidden window")
                     continue
                 }
             } else if !settings.countHiddenWindows && window.isMinimized != false {
@@ -88,6 +99,16 @@ final class WindowClassifier {
             }
 
             countable += 1
+        }
+
+        // Some apps report a minimized standard window as an auxiliary window. When minimized
+        // windows are counted, an auxiliary window alongside one standard window makes the
+        // last-window decision unsafe. When the user explicitly ignores minimized windows, a
+        // minimized auxiliary window remains ignored. With multiple standard windows, the
+        // decision is already non-terminal and remains unambiguous.
+        if countable == 1 && hasPotentiallyOpenAuxiliaryWindow {
+            ambiguous = true
+            reasons.append("Auxiliary window present alongside last standard window")
         }
 
         return WindowCountResult(count: countable, ambiguous: ambiguous, ignoredCount: ignored, reasons: reasons)

--- a/SmartCloseApp/Resources/Info-Debug.plist
+++ b/SmartCloseApp/Resources/Info-Debug.plist
@@ -23,7 +23,7 @@
     <key>LSApplicationCategoryType</key>
     <string>public.app-category.utilities</string>
     <key>LSUIElement</key>
-    <false/>
+    <true/>
     <key>NSHighResolutionCapable</key>
     <true/>
     <key>SUEnableAutomaticChecks</key>

--- a/SmartCloseTests/WindowClassifierTests.swift
+++ b/SmartCloseTests/WindowClassifierTests.swift
@@ -63,6 +63,106 @@ final class WindowClassifierTests: XCTestCase {
         XCTAssertTrue(result.ambiguous)
     }
 
+    func testAuxiliaryWindowAlongsideLastStandardWindowIsAmbiguous() {
+        let classifier = WindowClassifier()
+        let standardWindow = WindowInfo(
+            role: kAXWindowRole as String,
+            subrole: kAXStandardWindowSubrole as String,
+            isMinimized: false,
+            isVisible: true,
+            title: "Main"
+        )
+        let dialogWindow = WindowInfo(
+            role: kAXWindowRole as String,
+            subrole: kAXDialogSubrole as String,
+            isMinimized: true,
+            isVisible: false,
+            title: "Minimized window reported as dialog"
+        )
+
+        var settings = Settings.default
+        settings.countMinimizedWindows = true
+        settings.countHiddenWindows = true
+
+        let result = classifier.classify(
+            windows: [standardWindow, dialogWindow],
+            appIsHidden: false,
+            settings: settings
+        )
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.ignoredCount, 1)
+        XCTAssertTrue(result.ambiguous)
+        XCTAssertTrue(result.reasons.contains("Auxiliary window present alongside last standard window"))
+    }
+
+    func testMinimizedAuxiliaryWindowIsIgnoredWhenConfigured() {
+        let classifier = WindowClassifier()
+        let standardWindow = WindowInfo(
+            role: kAXWindowRole as String,
+            subrole: kAXStandardWindowSubrole as String,
+            isMinimized: false,
+            isVisible: true,
+            title: "Main"
+        )
+        let minimizedDialogWindow = WindowInfo(
+            role: kAXWindowRole as String,
+            subrole: kAXDialogSubrole as String,
+            isMinimized: true,
+            isVisible: false,
+            title: "Minimized window reported as dialog"
+        )
+
+        var settings = Settings.default
+        settings.countMinimizedWindows = false
+
+        let result = classifier.classify(
+            windows: [standardWindow, minimizedDialogWindow],
+            appIsHidden: false,
+            settings: settings
+        )
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.ignoredCount, 1)
+        XCTAssertFalse(result.ambiguous)
+        XCTAssertTrue(result.reasons.contains("Ignored minimized auxiliary subrole: AXDialog"))
+    }
+
+    func testAuxiliaryWindowAlongsideMultipleStandardWindowsIsNotAmbiguous() {
+        let classifier = WindowClassifier()
+        let standardWindow = WindowInfo(
+            role: kAXWindowRole as String,
+            subrole: kAXStandardWindowSubrole as String,
+            isMinimized: false,
+            isVisible: true,
+            title: "Main"
+        )
+        let secondStandardWindow = WindowInfo(
+            role: kAXWindowRole as String,
+            subrole: kAXStandardWindowSubrole as String,
+            isMinimized: false,
+            isVisible: true,
+            title: "Second"
+        )
+        let dialogWindow = WindowInfo(
+            role: kAXWindowRole as String,
+            subrole: kAXDialogSubrole as String,
+            isMinimized: false,
+            isVisible: true,
+            title: "Dialog"
+        )
+
+        let result = classifier.classify(
+            windows: [standardWindow, secondStandardWindow, dialogWindow],
+            appIsHidden: false,
+            settings: Settings.default
+        )
+
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result.ignoredCount, 1)
+        XCTAssertFalse(result.ambiguous)
+    }
+
     // MARK: - isStandardWindow (issue #6: closing an auxiliary window must not quit)
 
     func testIsStandardWindowTrueForStandardWindow() {


### PR DESCRIPTION
Safari was getting closed on me when I had a window minimized, even with "Ignore minimized windows" unchecked, because for some reason it is reporting the minimized window as AXDialog instead of AXStandardWindow. Fixed by marking this case as "ambiguous."


I accidentally unchecked "Show menu bar icon" and then couldn't ever find the app again to change it back... I made a change so that when the icon is hidden, launching the app a second time will open the settings window so you can still configure the app and/or bring the icon back.


Finally, I fixed the links in the README to use relative paths so they will work when the readme is displayed on github (or when someone has the repo checked out locally).


Thanks for this app, its been especially great for my older mother who struggles to understand the details of the app closing vs window closing.