### PR TITLE
Prepare SmartClose 0.3.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.3.4
+- Fix: Safari can expose a minimized standard window as `AXDialog`, which made SmartClose incorrectly treat the remaining visible window as the last window even when minimized windows were configured to count. SmartClose now treats this case as ambiguous and safely passes the close through (#11).
+- Fix: hiding the menu bar icon no longer leaves Settings unreachable. Launching SmartClose again opens Settings so the icon can be restored (#11).
+- Fix machine-specific README links so documentation and project links work on GitHub and in any local checkout (#11).
+
 ## 0.3.3
 - Fix: Cmd+W handling could pass through on macOS 26 when the just-closed last window was still reported briefly by the accessibility/window APIs (#8). SmartClose now retries the post-Cmd+W verification for a short bounded window and records the before/after samples in diagnostics.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <!-- Drop a short screen recording named example.gif in the repo root; it will render here automatically. -->
 ![SmartClose in action](example.gif)
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-3-orange.svg?style=flat-square)](#contributors)
 
 I created SmartClose because, recently, There are many new macos users arround and My self also switching between Windows and macOs too often, and I find it really annoying that when I click the red close button on the last window of an app, the app doesn't quit. So I made SmartClose to fix this issue.
 
@@ -62,6 +62,8 @@ Each release also includes a notarized ZIP of the same app bundle and a SHA-256 
 - Pause mode
 - Launch at login
 
+If you hide the menu bar icon, launch SmartClose again from Applications, Spotlight, or Finder to reopen Settings and restore the icon.
+
 ### Cmd+W handling (experimental)
 
 By default SmartClose only reacts to the red close button. You can optionally
@@ -117,6 +119,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/mahirozdin"><img src="https://avatars.githubusercontent.com/u/9491185?v=4?s=100" width="100px;" alt="Mahir Taha Özdin"/><br /><sub><b>Mahir Taha Özdin</b></sub></a><br /><a href="https://github.com/mahirozdin/SmartClose/commits?author=mahirozdin" title="Code">💻</a> <a href="https://github.com/mahirozdin/SmartClose/commits?author=mahirozdin" title="Documentation">📖</a> <a href="#maintenance-mahirozdin" title="Maintenance">🚧</a> <a href="#design-mahirozdin" title="Design">🎨</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/sohate"><img src="https://avatars.githubusercontent.com/u/81889148?v=4?s=100" width="100px;" alt="sohate"/><br /><sub><b>sohate</b></sub></a><br /><a href="#ideas-sohate" title="Ideas, Planning, & Feedback">🤔</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/cseelye"><img src="https://avatars.githubusercontent.com/u/15304724?v=4&amp;s=100" width="100px;" alt="Carl Seelye"/><br /><sub><b>Carl Seelye</b></sub></a><br /><a href="https://github.com/mahirozdin/SmartClose/commits?author=cseelye" title="Code">💻</a> <a href="https://github.com/mahirozdin/SmartClose/commits?author=cseelye" title="Documentation">📖</a> <a href="#bug-cseelye" title="Bug reports">🐛</a></td>
     </tr>
   </tbody>
 </table>

--- a/SmartClose.xcodeproj/project.pbxproj
+++ b/SmartClose.xcodeproj/project.pbxproj
@@ -544,7 +544,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_TEAM = WWRZ5CG3DW;
 				ENABLE_TESTABILITY = YES;
 				INFOPLIST_FILE = "SmartCloseApp/Resources/Info-Debug.plist";
@@ -553,7 +553,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 0.3.3;
+				MARKETING_VERSION = 0.3.4;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.smartclose.app;
 				PRODUCT_NAME = SmartClose;
@@ -614,7 +614,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_TEAM = WWRZ5CG3DW;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = SmartCloseApp/Resources/Info.plist;
@@ -623,7 +623,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 0.3.3;
+				MARKETING_VERSION = 0.3.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.smartclose.app;
 				PRODUCT_NAME = SmartClose;
 				SWIFT_VERSION = 6.0;


### PR DESCRIPTION
Prepare the v0.3.4 release after merging PR #11.

Changes:
- bump the app to version 0.3.4, build 7
- document the Safari and hidden-menu recovery fixes
- repair release-facing README guidance and credit the contributor

Validation:
- 54 unit tests passed
- 4 UI tests passed
- Debug analysis passed
- universal arm64/x86_64 Release build passed