### PR TITLE
Fix rapid Cmd+W closes and add Russian localization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.0
+- Fix: rapid multi-window `Cmd+W` sequences can leave a stale pre-close window count in macOS Accessibility, which prevented SmartClose from checking whether Terminal's final window had closed. SmartClose now arms verification for any confident positive pre-close count and still quits only after the post-close count reaches zero (#10).
+- Add a complete Russian interface covering onboarding, Settings, menu bar actions, permission and recovery states, diagnostics, app rules, and file panels (#14).
+
 ## 0.3.4
 - Fix: Safari can expose a minimized standard window as `AXDialog`, which made SmartClose incorrectly treat the remaining visible window as the last window even when minimized windows were configured to count. SmartClose now treats this case as ambiguous and safely passes the close through (#11).
 - Fix: hiding the menu bar icon no longer leaves Settings unreachable. Launching SmartClose again opens Settings so the icon can be restored (#11).

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ On macOS, clicking the red close button usually closes a window but keeps the ap
 - Accessibility permission
 - Input Monitoring permission
 
+SmartClose is available in English and Russian and follows your macOS language preference.
+
 ## Install
 
 ### Download a release

--- a/SmartClose.xcodeproj/project.pbxproj
+++ b/SmartClose.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		EE43CFAE1C104956925E45E6 /* WindowClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0985A33FF2A9460E9F5AB82C /* WindowClassifier.swift */; };
 		F015373D516A4B9181D22286 /* DecisionEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3332FEC90A4142AE834A9569 /* DecisionEngine.swift */; };
 		ACA7E700000000000000B17F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = ACA7E700000000000000F1EF /* Assets.xcassets */; };
+		B14A00000000000000000002 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = B14A00000000000000000001 /* Localizable.xcstrings */; };
 		5E7715C0DAB1E00000000002 /* SettingsCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7715C0DAB1E00000000001 /* SettingsCodableTests.swift */; };
 		5A8B1E00000000000000F11E /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 5A8B1E00000000000000D00D /* Sparkle */; };
 /* End PBXBuildFile section */
@@ -110,6 +111,7 @@
 		EA1A1A94DFAB4A4CB16F5957 /* EventMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventMonitor.swift; sourceTree = "<group>"; };
 		EEFCD85DD4EB4800ABFAEE10 /* AppRulesEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRulesEditorView.swift; sourceTree = "<group>"; };
 		ACA7E700000000000000F1EF /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		B14A00000000000000000001 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		5E7715C0DAB1E00000000001 /* SettingsCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsCodableTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -222,6 +224,7 @@
 			isa = PBXGroup;
 			children = (
 				ACA7E700000000000000F1EF /* Assets.xcassets */,
+				B14A00000000000000000001 /* Localizable.xcstrings */,
 				CAA19F8B53704F37BF51829B /* Info.plist */,
 				D0A1B2C3D4E5F60718293A4B /* Info-Debug.plist */,
 			);
@@ -435,6 +438,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				ru,
 				Base,
 			);
 			mainGroup = FCBC8C9A5587447CA81A73EF;
@@ -458,6 +462,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				ACA7E700000000000000B17F /* Assets.xcassets in Resources */,
+				B14A00000000000000000002 /* Localizable.xcstrings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -544,7 +549,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 8;
 				DEVELOPMENT_TEAM = WWRZ5CG3DW;
 				ENABLE_TESTABILITY = YES;
 				INFOPLIST_FILE = "SmartCloseApp/Resources/Info-Debug.plist";
@@ -552,11 +557,13 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 0.3.4;
+				MARKETING_VERSION = 0.4.0;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.smartclose.app;
 				PRODUCT_NAME = SmartClose;
+				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 6.0;
 			};
 			name = Debug;
@@ -614,7 +621,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 8;
 				DEVELOPMENT_TEAM = WWRZ5CG3DW;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = SmartCloseApp/Resources/Info.plist;
@@ -622,10 +629,12 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 0.3.4;
+				MARKETING_VERSION = 0.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.smartclose.app;
 				PRODUCT_NAME = SmartClose;
+				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 6.0;
 			};
 			name = Release;

--- a/SmartCloseApp/App/AppDelegate.swift
+++ b/SmartCloseApp/App/AppDelegate.swift
@@ -67,7 +67,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             .environmentObject(appModel.inputMonitoringManager)
             .environmentObject(updaterBridge)
         if settingsWindowController == nil {
-            settingsWindowController = HostingWindowController(title: "SmartClose Settings", rootView: AnyView(view))
+            settingsWindowController = HostingWindowController(title: String(localized: "SmartClose Settings"), rootView: AnyView(view))
         }
         settingsWindowController?.showWindow(nil)
         NSApp.activate(ignoringOtherApps: true)
@@ -78,7 +78,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let view = DiagnosticsView()
             .environmentObject(appModel.diagnosticsStore)
         if diagnosticsWindowController == nil {
-            diagnosticsWindowController = HostingWindowController(title: "SmartClose Diagnostics", rootView: AnyView(view))
+            diagnosticsWindowController = HostingWindowController(title: String(localized: "SmartClose Diagnostics"), rootView: AnyView(view))
         }
         diagnosticsWindowController?.showWindow(nil)
         NSApp.activate(ignoringOtherApps: true)
@@ -100,7 +100,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             .environmentObject(appModel.inputMonitoringManager)
             .environmentObject(appModel.settingsStore)
         if onboardingWindowController == nil {
-            onboardingWindowController = HostingWindowController(title: "Welcome to SmartClose", rootView: AnyView(view), size: NSSize(width: 560, height: 420))
+            onboardingWindowController = HostingWindowController(title: String(localized: "Welcome to SmartClose"), rootView: AnyView(view), size: NSSize(width: 560, height: 420))
         }
         onboardingWindowController?.showWindow(nil)
         NSApp.activate(ignoringOtherApps: true)

--- a/SmartCloseApp/App/AppModel.swift
+++ b/SmartCloseApp/App/AppModel.swift
@@ -110,7 +110,7 @@ final class AppModel {
                 eventMonitorState = .running
                 eventMonitorMessage = nil
             case .failure(let error):
-                let recoveryMessage = "macOS granted access, but SmartClose needs a relaunch to rebuild its event monitor."
+                let recoveryMessage = String(localized: "macOS granted access, but SmartClose needs a relaunch to rebuild its event monitor.")
                 permissionManager.setRecoveryMessage(nil)
                 inputMonitoringManager.setRecoveryMessage(recoveryMessage)
                 eventMonitorState = .failed
@@ -123,11 +123,11 @@ final class AppModel {
             inputMonitoringManager.setRecoveryMessage(nil)
             if isEnabled {
                 eventMonitorState = .idle
-                eventMonitorMessage = permissionsGranted ? nil : "Grant both permissions to start monitoring close-button clicks."
+                eventMonitorMessage = permissionsGranted ? nil : String(localized: "Grant both permissions to start monitoring close-button clicks.")
                 Log.app.info("Permissions missing. Event monitor idle.")
             } else {
                 eventMonitorState = .disabled
-                eventMonitorMessage = "SmartClose is disabled."
+                eventMonitorMessage = String(localized: "SmartClose is disabled.")
                 Log.app.info("SmartClose disabled. Event monitor stopped.")
             }
         }

--- a/SmartCloseApp/Core/AppRules/AppPolicyResolver.swift
+++ b/SmartCloseApp/Core/AppRules/AppPolicyResolver.swift
@@ -33,18 +33,18 @@ final class AppPolicyResolver {
 
     func resolve(bundleID: String, settings: Settings) -> ResolvedPolicy {
         if matchesAny(patterns: hardExcludedBundleIDs, bundleID: bundleID) {
-            return ResolvedPolicy(behavior: .disabled, matchedRule: "Hard exclusion", isExcluded: true)
+            return ResolvedPolicy(behavior: .disabled, matchedRule: String(localized: "Hard exclusion"), isExcluded: true)
         }
 
         if settings.useAllowList {
             let isAllowed = matchesAny(patterns: settings.allowedBundleIDs, bundleID: bundleID)
             if !isAllowed {
-                return ResolvedPolicy(behavior: .disabled, matchedRule: "Allow list", isExcluded: true)
+                return ResolvedPolicy(behavior: .disabled, matchedRule: String(localized: "Allow list"), isExcluded: true)
             }
         }
 
         if matchesAny(patterns: settings.ignoredBundleIDs, bundleID: bundleID) {
-            return ResolvedPolicy(behavior: .disabled, matchedRule: "Ignored bundle", isExcluded: true)
+            return ResolvedPolicy(behavior: .disabled, matchedRule: String(localized: "Ignored bundle"), isExcluded: true)
         }
 
         if let exactRule = settings.perAppRules[bundleID] {

--- a/SmartCloseApp/Core/DecisionEngine/DecisionEngine.swift
+++ b/SmartCloseApp/Core/DecisionEngine/DecisionEngine.swift
@@ -3,6 +3,15 @@ import Foundation
 enum DecisionAction: String, Codable {
     case passThrough
     case requestQuit
+
+    var displayName: String {
+        switch self {
+        case .passThrough:
+            return String(localized: "Pass through")
+        case .requestQuit:
+            return String(localized: "Request quit")
+        }
+    }
 }
 
 struct DecisionContext {
@@ -24,57 +33,60 @@ struct DecisionResult: Codable {
 struct DecisionEngine {
     func decide(context: DecisionContext) -> DecisionResult {
         if !context.isEnabled {
-            return DecisionResult(action: .passThrough, reason: "SmartClose disabled")
+            return DecisionResult(action: .passThrough, reason: String(localized: "SmartClose disabled"))
         }
 
         if context.isPaused {
-            return DecisionResult(action: .passThrough, reason: "Paused")
+            return DecisionResult(action: .passThrough, reason: String(localized: "Paused"))
         }
 
         if !context.permissionGranted {
-            return DecisionResult(action: .passThrough, reason: "Accessibility permission missing")
+            return DecisionResult(action: .passThrough, reason: String(localized: "Accessibility permission missing"))
         }
 
         if context.resolvedPolicy.isExcluded || context.resolvedPolicy.behavior == .disabled {
-            return DecisionResult(action: .passThrough, reason: "Excluded by policy")
+            return DecisionResult(action: .passThrough, reason: String(localized: "Excluded by policy"))
         }
 
         if context.resolvedPolicy.behavior == .alwaysNormalClose {
-            return DecisionResult(action: .passThrough, reason: "Always normal close policy")
+            return DecisionResult(action: .passThrough, reason: String(localized: "Always normal close policy"))
         }
 
         // Only the close button of a standard window can quit the app. Closing an auxiliary
         // window (Find & Replace, a dialog, a floating inspector, …) leaves the real windows
         // open, so it must pass through even if exactly one normal window exists (issue #6).
         if !context.closedWindowIsStandard {
-            return DecisionResult(action: .passThrough, reason: "Closed window is not a standard window")
+            return DecisionResult(action: .passThrough, reason: String(localized: "Closed window is not a standard window"))
         }
 
         guard let windowCount = context.windowCount else {
-            return DecisionResult(action: .passThrough, reason: "Window count unavailable")
+            return DecisionResult(action: .passThrough, reason: String(localized: "Window count unavailable"))
         }
 
         if windowCount.ambiguous {
-            return DecisionResult(action: .passThrough, reason: "Ambiguous window classification")
+            return DecisionResult(action: .passThrough, reason: String(localized: "Ambiguous window classification"))
         }
 
         if windowCount.count == 1 {
-            return DecisionResult(action: .requestQuit, reason: "Last normal window")
+            return DecisionResult(action: .requestQuit, reason: String(localized: "Last normal window"))
         }
 
         if windowCount.count == 0 {
-            return DecisionResult(action: .passThrough, reason: "No countable windows")
+            return DecisionResult(action: .passThrough, reason: String(localized: "No countable windows"))
         }
 
-        return DecisionResult(action: .passThrough, reason: "Multiple windows open")
+        return DecisionResult(action: .passThrough, reason: String(localized: "Multiple windows open"))
     }
 
     /// Decision for the optional Cmd+W path. Unlike `decide`, the keystroke is never
     /// swallowed: the app closes its own window first, then this is evaluated using the window
     /// count from *before* the keystroke and from *after*.
     ///
-    /// We act only when there was exactly one confidently-classified normal window **before**
-    /// Cmd+W (a plausible "last window"), and the app reports zero windows **after**.
+    /// We act only when there was at least one confidently-classified normal window **before**
+    /// Cmd+W and the app reports zero windows **after**. Accepting a positive pre-close count is
+    /// important for rapid multi-window sequences: Accessibility can briefly keep the previously
+    /// closed window in its list, so the final Cmd+W may still observe a stale count greater than
+    /// one (issue #10). The zero-window after-state remains the only quit trigger.
     ///
     /// Important: an app with no remaining windows reports `count == 0` but the window counter
     /// also flags that result `ambiguous` ("No windows returned"). So for the *after* state we
@@ -90,37 +102,37 @@ struct DecisionEngine {
         windowsAfter: WindowCountResult?
     ) -> DecisionResult {
         if !isEnabled {
-            return DecisionResult(action: .passThrough, reason: "SmartClose disabled")
+            return DecisionResult(action: .passThrough, reason: String(localized: "SmartClose disabled"))
         }
 
         if isPaused {
-            return DecisionResult(action: .passThrough, reason: "Paused")
+            return DecisionResult(action: .passThrough, reason: String(localized: "Paused"))
         }
 
         if !permissionGranted {
-            return DecisionResult(action: .passThrough, reason: "Accessibility permission missing")
+            return DecisionResult(action: .passThrough, reason: String(localized: "Accessibility permission missing"))
         }
 
         if resolvedPolicy.isExcluded || resolvedPolicy.behavior == .disabled {
-            return DecisionResult(action: .passThrough, reason: "Excluded by policy")
+            return DecisionResult(action: .passThrough, reason: String(localized: "Excluded by policy"))
         }
 
         if resolvedPolicy.behavior == .alwaysNormalClose {
-            return DecisionResult(action: .passThrough, reason: "Always normal close policy")
+            return DecisionResult(action: .passThrough, reason: String(localized: "Always normal close policy"))
         }
 
-        guard let before = windowsBefore, before.count == 1, !before.ambiguous else {
-            return DecisionResult(action: .passThrough, reason: "Not a single normal window before Cmd+W")
+        guard let before = windowsBefore, before.count > 0, !before.ambiguous else {
+            return DecisionResult(action: .passThrough, reason: String(localized: "No confident normal window before Cmd+W"))
         }
 
         guard let after = windowsAfter else {
-            return DecisionResult(action: .passThrough, reason: "Window count unavailable")
+            return DecisionResult(action: .passThrough, reason: String(localized: "Window count unavailable"))
         }
 
         if after.count == 0 {
-            return DecisionResult(action: .requestQuit, reason: "Last window closed via Cmd+W")
+            return DecisionResult(action: .requestQuit, reason: String(localized: "Last window closed via Cmd+W"))
         }
 
-        return DecisionResult(action: .passThrough, reason: "Window still open after Cmd+W")
+        return DecisionResult(action: .passThrough, reason: String(localized: "Window still open after Cmd+W"))
     }
 }

--- a/SmartCloseApp/Core/Interception/EventMonitor.swift
+++ b/SmartCloseApp/Core/Interception/EventMonitor.swift
@@ -12,7 +12,7 @@ enum EventMonitorError: Error, Equatable {
     var message: String {
         switch self {
         case .tapCreationFailed:
-            return "macOS did not allow SmartClose to create its global event tap."
+            return String(localized: "macOS did not allow SmartClose to create its global event tap.")
         }
     }
 }

--- a/SmartCloseApp/Core/Interception/InterceptionController.swift
+++ b/SmartCloseApp/Core/Interception/InterceptionController.swift
@@ -130,10 +130,10 @@ final class InterceptionController: @unchecked Sendable {
             logDecision(
                 app: runningApp,
                 bundleID: bundleID,
-                decision: DecisionResult(action: .passThrough, reason: "Excluded by policy"),
+                decision: DecisionResult(action: .passThrough, reason: String(localized: "Excluded by policy")),
                 windowCount: nil,
                 ignoredCount: nil,
-                actionTaken: "None"
+                actionTaken: String(localized: "None")
             )
             return .passThrough
         }
@@ -180,7 +180,7 @@ final class InterceptionController: @unchecked Sendable {
                 decision: decision,
                 windowCount: windowCountResult?.count,
                 ignoredCount: windowCountResult?.ignoredCount,
-                actionTaken: success ? "Requested quit" : "Quit request failed"
+                actionTaken: success ? String(localized: "Requested quit") : String(localized: "Quit request failed")
             )
             return .swallow
         }
@@ -191,7 +191,7 @@ final class InterceptionController: @unchecked Sendable {
             decision: decision,
             windowCount: windowCountResult?.count,
             ignoredCount: windowCountResult?.ignoredCount,
-            actionTaken: "Passed through"
+            actionTaken: String(localized: "Passed through")
         )
         return .passThrough
     }
@@ -225,12 +225,12 @@ final class InterceptionController: @unchecked Sendable {
         guard policyResolver.cmdWEnabled(bundleID: bundleID, settings: settings) else { return }
 
         // Count windows BEFORE the app handles Cmd+W. The keystroke has only been observed
-        // (the event tap runs before delivery), so the target window is still open here. Only
-        // arm when there is exactly one confidently-classified normal window — a plausible
-        // "last window" — otherwise Cmd+W is just closing a tab/secondary window and we leave
-        // it alone.
+        // (the event tap runs before delivery), so the target window is still open here. Arm for
+        // any confidently-classified positive count and quit only if verification later reaches
+        // zero. This also covers rapid multi-window sequences where Accessibility still reports
+        // the penultimate, just-closed window when the final Cmd+W arrives (issue #10).
         let windowsBefore = windowCountingService.countWindows(for: pid, appIsHidden: app.isHidden, settings: settings)
-        guard let windowsBefore, windowsBefore.count == 1, !windowsBefore.ambiguous else {
+        guard let windowsBefore, windowsBefore.count > 0, !windowsBefore.ambiguous else {
             if settings.debugLoggingLevel == .verbose {
                 Log.interception.debug("Cmd+W not armed bundle=\(bundleID) before=\(windowsBefore?.count ?? -1) ambiguous=\(windowsBefore?.ambiguous ?? true)")
             }
@@ -292,7 +292,7 @@ final class InterceptionController: @unchecked Sendable {
                 decision: decision,
                 windowCount: windowsAfter?.count,
                 ignoredCount: windowsAfter?.ignoredCount,
-                actionTaken: success ? "Requested quit (Cmd+W)" : "Quit request failed (Cmd+W)",
+                actionTaken: success ? String(localized: "Requested quit (Cmd+W)") : String(localized: "Quit request failed (Cmd+W)"),
                 details: cmdWVerificationDetails(windowsBefore: windowsBefore, samples: samples, elapsed: elapsed)
             )
         } else if let nextDelay = verificationPolicy.nextDelay(afterElapsed: elapsed, latestResult: windowsAfter) {
@@ -315,7 +315,7 @@ final class InterceptionController: @unchecked Sendable {
                 decision: decision,
                 windowCount: windowsAfter?.count,
                 ignoredCount: windowsAfter?.ignoredCount,
-                actionTaken: "Passed through (Cmd+W)",
+                actionTaken: String(localized: "Passed through (Cmd+W)"),
                 details: cmdWVerificationDetails(windowsBefore: windowsBefore, samples: samples, elapsed: elapsed)
             )
         }
@@ -369,7 +369,7 @@ final class InterceptionController: @unchecked Sendable {
         let event = DiagnosticEvent(
             id: UUID(),
             timestamp: Date(),
-            appName: app.localizedName ?? "Unknown",
+            appName: app.localizedName ?? String(localized: "Unknown"),
             bundleID: bundleID,
             windowCount: windowCount,
             ignoredCount: ignoredCount,

--- a/SmartCloseApp/Core/Permissions/InputMonitoringManager.swift
+++ b/SmartCloseApp/Core/Permissions/InputMonitoringManager.swift
@@ -130,18 +130,18 @@ final class InputMonitoringManager: ObservableObject {
     private var message: String {
         switch rowStatus {
         case .unknown:
-            return "Checking the current macOS permission state."
+            return String(localized: "Checking the current macOS permission state.")
         case .missing:
             if hasRequestedSystemPrompt {
-                return "If the prompt did not appear or was denied, enable SmartClose manually in System Settings."
+                return String(localized: "If the prompt did not appear or was denied, enable SmartClose manually in System Settings.")
             }
-            return "SmartClose needs this before it can monitor close-button clicks."
+            return String(localized: "SmartClose needs this before it can monitor close-button clicks.")
         case .requesting:
-            return "Approve SmartClose in the macOS prompt to continue."
+            return String(localized: "Approve SmartClose in the macOS prompt to continue.")
         case .granted:
-            return "SmartClose can monitor close-button clicks."
+            return String(localized: "SmartClose can monitor close-button clicks.")
         case .recoveryNeeded:
-            return recoveryMessage ?? "macOS granted access, but SmartClose needs a relaunch to restart event monitoring."
+            return recoveryMessage ?? String(localized: "macOS granted access, but SmartClose needs a relaunch to restart event monitoring.")
         }
     }
 
@@ -165,7 +165,7 @@ final class InputMonitoringManager: ObservableObject {
             isGranted = true
             rowStatus = .granted
         case .recovery:
-            recoveryMessage = "Relaunch SmartClose to rebuild the global event tap."
+            recoveryMessage = String(localized: "Relaunch SmartClose to rebuild the global event tap.")
             isGranted = true
             rowStatus = .recoveryNeeded
         }

--- a/SmartCloseApp/Core/Permissions/PermissionManager.swift
+++ b/SmartCloseApp/Core/Permissions/PermissionManager.swift
@@ -12,18 +12,18 @@ enum PermissionKind: String, Identifiable {
     var title: String {
         switch self {
         case .accessibility:
-            return "Accessibility"
+            return String(localized: "Accessibility")
         case .inputMonitoring:
-            return "Input Monitoring"
+            return String(localized: "Input Monitoring")
         }
     }
 
     var reason: String {
         switch self {
         case .accessibility:
-            return "Needed to inspect windows and confirm the red close button safely."
+            return String(localized: "Needed to inspect windows and confirm the red close button safely.")
         case .inputMonitoring:
-            return "Needed to receive global close-button clicks before macOS handles them."
+            return String(localized: "Needed to receive global close-button clicks before macOS handles them.")
         }
     }
 }
@@ -38,15 +38,15 @@ enum PermissionRowStatus: String, Equatable {
     var label: String {
         switch self {
         case .unknown:
-            return "Checking"
+            return String(localized: "Checking")
         case .missing:
-            return "Missing"
+            return String(localized: "Missing")
         case .requesting:
-            return "Waiting for macOS"
+            return String(localized: "Waiting for macOS")
         case .granted:
-            return "Granted"
+            return String(localized: "Granted")
         case .recoveryNeeded:
-            return "Needs relaunch"
+            return String(localized: "Needs relaunch")
         }
     }
 }
@@ -60,11 +60,11 @@ enum PermissionRowAction: Equatable {
     var title: String? {
         switch self {
         case .requestSystemPrompt:
-            return "Grant Access"
+            return String(localized: "Grant Access")
         case .openSettings:
-            return "Open Settings"
+            return String(localized: "Open Settings")
         case .relaunchApp:
-            return "Relaunch SmartClose"
+            return String(localized: "Relaunch SmartClose")
         case .none:
             return nil
         }
@@ -275,18 +275,18 @@ final class PermissionManager: ObservableObject, PermissionManaging {
     private var message: String {
         switch rowStatus {
         case .unknown:
-            return "Checking the current macOS permission state."
+            return String(localized: "Checking the current macOS permission state.")
         case .missing:
             if hasRequestedSystemPrompt {
-                return "If the prompt did not appear or was denied, enable SmartClose manually in System Settings."
+                return String(localized: "If the prompt did not appear or was denied, enable SmartClose manually in System Settings.")
             }
-            return "SmartClose needs this before it can inspect windows."
+            return String(localized: "SmartClose needs this before it can inspect windows.")
         case .requesting:
-            return "Approve SmartClose in the macOS prompt to continue."
+            return String(localized: "Approve SmartClose in the macOS prompt to continue.")
         case .granted:
-            return "SmartClose can inspect windows."
+            return String(localized: "SmartClose can inspect windows.")
         case .recoveryNeeded:
-            return recoveryMessage ?? "macOS granted access, but SmartClose needs a relaunch to start monitoring."
+            return recoveryMessage ?? String(localized: "macOS granted access, but SmartClose needs a relaunch to start monitoring.")
         }
     }
 
@@ -310,7 +310,7 @@ final class PermissionManager: ObservableObject, PermissionManaging {
             isGranted = true
             rowStatus = .granted
         case .recovery:
-            recoveryMessage = "Relaunch SmartClose to reattach its event monitor."
+            recoveryMessage = String(localized: "Relaunch SmartClose to reattach its event monitor.")
             isGranted = true
             rowStatus = .recoveryNeeded
         }

--- a/SmartCloseApp/Core/Persistence/Settings.swift
+++ b/SmartCloseApp/Core/Persistence/Settings.swift
@@ -8,8 +8,8 @@ enum GlobalMode: String, Codable, CaseIterable, Identifiable {
 
     var displayName: String {
         switch self {
-        case .smartClose: return "Smart close (quit on last window)"
-        case .alwaysNormalClose: return "Always normal close"
+        case .smartClose: return String(localized: "Smart close (quit on last window)")
+        case .alwaysNormalClose: return String(localized: "Always normal close")
         }
     }
 }
@@ -24,10 +24,10 @@ enum AppPolicy: String, Codable, CaseIterable, Identifiable {
 
     var displayName: String {
         switch self {
-        case .default: return "Default"
-        case .alwaysNormalClose: return "Always normal close"
-        case .alwaysQuitOnLastWindow: return "Always quit on last window"
-        case .disabled: return "Disabled for this app"
+        case .default: return String(localized: "Default")
+        case .alwaysNormalClose: return String(localized: "Always normal close")
+        case .alwaysQuitOnLastWindow: return String(localized: "Always quit on last window")
+        case .disabled: return String(localized: "Disabled for this app")
         }
     }
 }
@@ -42,10 +42,10 @@ enum DebugLoggingLevel: String, Codable, CaseIterable, Identifiable {
 
     var displayName: String {
         switch self {
-        case .none: return "None"
-        case .error: return "Errors only"
-        case .info: return "Info"
-        case .verbose: return "Verbose"
+        case .none: return String(localized: "None")
+        case .error: return String(localized: "Errors only")
+        case .info: return String(localized: "Info")
+        case .verbose: return String(localized: "Verbose")
         }
     }
 }

--- a/SmartCloseApp/Core/Persistence/SettingsStore.swift
+++ b/SmartCloseApp/Core/Persistence/SettingsStore.swift
@@ -63,7 +63,7 @@ final class SettingsStore: ObservableObject {
     @MainActor
     func exportToFile() {
         let panel = NSSavePanel()
-        panel.title = "Export SmartClose Settings"
+        panel.title = String(localized: "Export SmartClose Settings")
         panel.allowedContentTypes = [.json]
         panel.nameFieldStringValue = "SmartCloseSettings.json"
         if panel.runModal() == .OK, let url = panel.url {
@@ -79,7 +79,7 @@ final class SettingsStore: ObservableObject {
     @MainActor
     func importFromFile() {
         let panel = NSOpenPanel()
-        panel.title = "Import SmartClose Settings"
+        panel.title = String(localized: "Import SmartClose Settings")
         panel.allowedContentTypes = [.json]
         panel.allowsMultipleSelection = false
         if panel.runModal() == .OK, let url = panel.url {

--- a/SmartCloseApp/Diagnostics/DiagnosticsStore.swift
+++ b/SmartCloseApp/Diagnostics/DiagnosticsStore.swift
@@ -23,13 +23,13 @@ enum EventMonitorRuntimeState: String, Equatable {
     var label: String {
         switch self {
         case .idle:
-            return "Idle"
+            return String(localized: "Idle")
         case .disabled:
-            return "Disabled"
+            return String(localized: "Disabled")
         case .running:
-            return "Running"
+            return String(localized: "Running")
         case .failed:
-            return "Failed"
+            return String(localized: "Failed")
         }
     }
 }
@@ -47,13 +47,13 @@ struct PermissionDiagnosticsSnapshot: Equatable {
             kind: .accessibility,
             status: .unknown,
             action: .requestSystemPrompt,
-            message: "Checking the current macOS permission state."
+            message: String(localized: "Checking the current macOS permission state.")
         ),
         inputMonitoringRow: PermissionRowModel(
             kind: .inputMonitoring,
             status: .unknown,
             action: .requestSystemPrompt,
-            message: "Checking the current macOS permission state."
+            message: String(localized: "Checking the current macOS permission state.")
         ),
         eventMonitorState: .idle,
         eventMonitorMessage: nil
@@ -90,9 +90,9 @@ final class DiagnosticsStore: ObservableObject {
     }
 
     func frontmostAppSummary() -> String {
-        guard let app = NSWorkspace.shared.frontmostApplication else { return "Unknown" }
-        let name = app.localizedName ?? "Unknown"
-        let bundle = app.bundleIdentifier ?? "Unknown"
+        guard let app = NSWorkspace.shared.frontmostApplication else { return String(localized: "Unknown") }
+        let name = app.localizedName ?? String(localized: "Unknown")
+        let bundle = app.bundleIdentifier ?? String(localized: "Unknown")
         return "\(name) (\(bundle))"
     }
 }

--- a/SmartCloseApp/Diagnostics/DiagnosticsView.swift
+++ b/SmartCloseApp/Diagnostics/DiagnosticsView.swift
@@ -13,12 +13,12 @@ struct DiagnosticsView: View {
 
             GroupBox(label: Text("Permission Health")) {
                 VStack(alignment: .leading, spacing: 10) {
-                    DiagnosticRow(label: "Bundle ID", value: snapshot.appIdentity.bundleID)
-                    DiagnosticRow(label: "Code-Signing ID", value: snapshot.appIdentity.codeSigningIdentifier)
-                    DiagnosticRow(label: "Bundle Path", value: snapshot.appIdentity.bundlePath)
-                    DiagnosticRow(label: "Accessibility", value: snapshot.accessibilityRow.status.label)
-                    DiagnosticRow(label: "Input Monitoring", value: snapshot.inputMonitoringRow.status.label)
-                    DiagnosticRow(label: "Event Monitor", value: snapshot.eventMonitorState.label)
+                    DiagnosticRow(label: String(localized: "Bundle ID"), value: snapshot.appIdentity.bundleID)
+                    DiagnosticRow(label: String(localized: "Code-Signing ID"), value: snapshot.appIdentity.codeSigningIdentifier)
+                    DiagnosticRow(label: String(localized: "Bundle Path"), value: snapshot.appIdentity.bundlePath)
+                    DiagnosticRow(label: String(localized: "Accessibility"), value: snapshot.accessibilityRow.status.label)
+                    DiagnosticRow(label: String(localized: "Input Monitoring"), value: snapshot.inputMonitoringRow.status.label)
+                    DiagnosticRow(label: String(localized: "Event Monitor"), value: snapshot.eventMonitorState.label)
 
                     if let eventMonitorMessage = snapshot.eventMonitorMessage {
                         Text(eventMonitorMessage)
@@ -56,7 +56,7 @@ struct DiagnosticsView: View {
                     Text("App: \(latest.appName) (\(latest.bundleID))")
                     Text("Window count: \(latest.windowCount.map(String.init) ?? "-")")
                     Text("Ignored windows: \(latest.ignoredCount.map(String.init) ?? "-")")
-                    Text("Decision: \(latest.decision.rawValue)")
+                    Text("Decision: \(latest.decision.displayName)")
                     Text("Reason: \(latest.reason)")
                     Text("Action taken: \(latest.actionTaken)")
                     if let details = latest.details, !details.isEmpty {
@@ -77,7 +77,7 @@ struct DiagnosticsView: View {
 
             List(diagnosticsStore.events) { event in
                 VStack(alignment: .leading, spacing: 4) {
-                    Text("\(event.appName) - \(event.decision.rawValue)")
+                    Text("\(event.appName) - \(event.decision.displayName)")
                         .font(.headline)
                     Text(event.reason)
                         .font(.subheadline)

--- a/SmartCloseApp/MenuBar/StatusMenuController.swift
+++ b/SmartCloseApp/MenuBar/StatusMenuController.swift
@@ -56,47 +56,47 @@ final class StatusMenuController {
     }
 
     private func buildMenu() {
-        statusItemLabel = NSMenuItem(title: "Status: Unknown", action: nil, keyEquivalent: "")
+        statusItemLabel = NSMenuItem(title: String(localized: "Status: Unknown"), action: nil, keyEquivalent: "")
         menu.addItem(statusItemLabel)
 
-        enabledItem = NSMenuItem(title: "Enable SmartClose", action: #selector(toggleEnabled), keyEquivalent: "")
+        enabledItem = NSMenuItem(title: String(localized: "Enable SmartClose"), action: #selector(toggleEnabled), keyEquivalent: "")
         enabledItem.target = self
         menu.addItem(enabledItem)
 
-        pauseItem = NSMenuItem(title: "Pause for 1 hour", action: #selector(pauseForHour), keyEquivalent: "")
+        pauseItem = NSMenuItem(title: String(localized: "Pause for 1 hour"), action: #selector(pauseForHour), keyEquivalent: "")
         pauseItem.target = self
         menu.addItem(pauseItem)
 
         menu.addItem(.separator())
 
-        let settingsItem = NSMenuItem(title: "Open Settings", action: #selector(openSettings), keyEquivalent: ",")
+        let settingsItem = NSMenuItem(title: String(localized: "Open Settings"), action: #selector(openSettings), keyEquivalent: ",")
         settingsItem.target = self
         menu.addItem(settingsItem)
 
-        let diagnosticsItem = NSMenuItem(title: "Show Diagnostics", action: #selector(showDiagnostics), keyEquivalent: "d")
+        let diagnosticsItem = NSMenuItem(title: String(localized: "Show Diagnostics"), action: #selector(showDiagnostics), keyEquivalent: "d")
         diagnosticsItem.target = self
         menu.addItem(diagnosticsItem)
 
-        let updatesItem = NSMenuItem(title: "Check for Updates…", action: #selector(checkForUpdates), keyEquivalent: "")
+        let updatesItem = NSMenuItem(title: String(localized: "Check for Updates…"), action: #selector(checkForUpdates), keyEquivalent: "")
         updatesItem.target = self
         menu.addItem(updatesItem)
 
         menu.addItem(.separator())
 
-        let quitItem = NSMenuItem(title: "Quit SmartClose", action: #selector(quitApp), keyEquivalent: "q")
+        let quitItem = NSMenuItem(title: String(localized: "Quit SmartClose"), action: #selector(quitApp), keyEquivalent: "q")
         quitItem.target = self
         menu.addItem(quitItem)
     }
 
     private func updateMenu(settings: Settings) {
-        let statusText = settings.isEnabled ? "Enabled" : "Disabled"
-        statusItemLabel.title = "Status: \(statusText)"
-        enabledItem.title = settings.isEnabled ? "Disable SmartClose" : "Enable SmartClose"
+        let statusText = settings.isEnabled ? String(localized: "Enabled") : String(localized: "Disabled")
+        statusItemLabel.title = String.localizedStringWithFormat(String(localized: "Status: %@"), statusText)
+        enabledItem.title = settings.isEnabled ? String(localized: "Disable SmartClose") : String(localized: "Enable SmartClose")
 
         if settings.isPaused {
-            pauseItem.title = "Resume SmartClose"
+            pauseItem.title = String(localized: "Resume SmartClose")
         } else {
-            pauseItem.title = "Pause for 1 hour"
+            pauseItem.title = String(localized: "Pause for 1 hour")
         }
 
         statusItem.isVisible = settings.showMenuBarIcon

--- a/SmartCloseApp/Resources/Localizable.xcstrings
+++ b/SmartCloseApp/Resources/Localizable.xcstrings
@@ -1,0 +1,1409 @@
+{
+  "sourceLanguage": "en",
+  "strings": {
+    "": {},
+    "%@ - %@": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ — %2$@"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ - %2$@"
+          }
+        }
+      }
+    },
+    "Accessibility": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Универсальный доступ"
+          }
+        }
+      }
+    },
+    "Accessibility permission missing": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нет разрешения на универсальный доступ"
+          }
+        }
+      }
+    },
+    "Action taken: %@": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выполненное действие: %@"
+          }
+        }
+      }
+    },
+    "Add": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Добавить"
+          }
+        }
+      }
+    },
+    "All set": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Всё готово"
+          }
+        }
+      }
+    },
+    "Allow List": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Список разрешённых"
+          }
+        }
+      }
+    },
+    "Allow list": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Список разрешённых"
+          }
+        }
+      }
+    },
+    "Always normal close": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Всегда обычное закрытие"
+          }
+        }
+      }
+    },
+    "Always normal close policy": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Политика обычного закрытия"
+          }
+        }
+      }
+    },
+    "Always quit on last window": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Всегда завершать при последнем окне"
+          }
+        }
+      }
+    },
+    "Ambiguous window classification": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Неоднозначная классификация окон"
+          }
+        }
+      }
+    },
+    "App Path": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Путь к приложению"
+          }
+        }
+      }
+    },
+    "App Rules": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Правила приложений"
+          }
+        }
+      }
+    },
+    "App: %@ (%@)": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Приложение: %1$@ (%2$@)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App: %1$@ (%2$@)"
+          }
+        }
+      }
+    },
+    "Approve SmartClose in the macOS prompt to continue.": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подтвердите доступ для SmartClose в запросе macOS, чтобы продолжить."
+          }
+        }
+      }
+    },
+    "Automatically check for updates": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Автоматически проверять обновления"
+          }
+        }
+      }
+    },
+    "Back": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Назад"
+          }
+        }
+      }
+    },
+    "Behavior": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поведение"
+          }
+        }
+      }
+    },
+    "Bundle ID": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Идентификатор пакета"
+          }
+        }
+      }
+    },
+    "Bundle ID or pattern": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Идентификатор пакета или шаблон"
+          }
+        }
+      }
+    },
+    "Bundle Path": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Путь к пакету"
+          }
+        }
+      }
+    },
+    "Check for Updates…": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проверить обновления…"
+          }
+        }
+      }
+    },
+    "Checking": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проверка"
+          }
+        }
+      }
+    },
+    "Checking the current macOS permission state.": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проверка текущего состояния разрешений macOS."
+          }
+        }
+      }
+    },
+    "Closed window is not a standard window": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Закрытое окно не является стандартным"
+          }
+        }
+      }
+    },
+    "Code-Signing ID": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Идентификатор подписи кода"
+          }
+        }
+      }
+    },
+    "Continue": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Продолжить"
+          }
+        }
+      }
+    },
+    "Copy App Path": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скопировать путь к приложению"
+          }
+        }
+      }
+    },
+    "Debug logging": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Журнал отладки"
+          }
+        }
+      }
+    },
+    "Decision: %@": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Решение: %@"
+          }
+        }
+      }
+    },
+    "Default": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "По умолчанию"
+          }
+        }
+      }
+    },
+    "Diagnostics": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Диагностика"
+          }
+        }
+      }
+    },
+    "Disable SmartClose": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отключить SmartClose"
+          }
+        }
+      }
+    },
+    "Disabled": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отключено"
+          }
+        }
+      }
+    },
+    "Disabled for this app": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отключено для этого приложения"
+          }
+        }
+      }
+    },
+    "Enable SmartClose": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Включить SmartClose"
+          }
+        }
+      }
+    },
+    "Enable diagnostics": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Включить диагностику"
+          }
+        }
+      }
+    },
+    "Enabled": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Включено"
+          }
+        }
+      }
+    },
+    "Errors only": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Только ошибки"
+          }
+        }
+      }
+    },
+    "Event Monitor": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Монитор событий"
+          }
+        }
+      }
+    },
+    "Excluded by policy": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Исключено политикой"
+          }
+        }
+      }
+    },
+    "Export Settings": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Экспортировать настройки"
+          }
+        }
+      }
+    },
+    "Export SmartClose Settings": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Экспорт настроек SmartClose"
+          }
+        }
+      }
+    },
+    "Failed": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ошибка"
+          }
+        }
+      }
+    },
+    "Finish": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Готово"
+          }
+        }
+      }
+    },
+    "Frontmost App": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Активное приложение"
+          }
+        }
+      }
+    },
+    "Global mode": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Глобальный режим"
+          }
+        }
+      }
+    },
+    "Grant Access": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Предоставить доступ"
+          }
+        }
+      }
+    },
+    "Grant both permissions below before SmartClose starts intercepting the red close button.": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Предоставьте оба разрешения ниже, прежде чем SmartClose начнёт отслеживать нажатия красной кнопки закрытия."
+          }
+        }
+      }
+    },
+    "Grant both permissions to start monitoring close-button clicks.": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Предоставьте оба разрешения, чтобы начать отслеживание нажатий кнопки закрытия."
+          }
+        }
+      }
+    },
+    "Granted": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Разрешено"
+          }
+        }
+      }
+    },
+    "Handle Cmd+W (experimental)": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обрабатывать Cmd+W (экспериментально)"
+          }
+        }
+      }
+    },
+    "Hard exclusion": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Жёсткое исключение"
+          }
+        }
+      }
+    },
+    "Idle": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ожидание"
+          }
+        }
+      }
+    },
+    "If permissions look stale after a signing or Debug-build change, reset TCC for SmartClose and try again:": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Если состояние разрешений устарело после изменения подписи или Debug-сборки, сбросьте TCC для SmartClose и попробуйте снова:"
+          }
+        }
+      }
+    },
+    "If the prompt did not appear or was denied, enable SmartClose manually in System Settings.": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Если запрос не появился или был отклонён, включите SmartClose вручную в Системных настройках."
+          }
+        }
+      }
+    },
+    "Ignore List": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Список исключений"
+          }
+        }
+      }
+    },
+    "Ignore hidden windows": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Игнорировать скрытые окна"
+          }
+        }
+      }
+    },
+    "Ignore minimized windows": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Игнорировать свёрнутые окна"
+          }
+        }
+      }
+    },
+    "Ignored bundle": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Исключённый пакет"
+          }
+        }
+      }
+    },
+    "Ignored windows: %@": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Игнорируемых окон: %@"
+          }
+        }
+      }
+    },
+    "Import Settings": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Импортировать настройки"
+          }
+        }
+      }
+    },
+    "Import SmartClose Settings": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Импорт настроек SmartClose"
+          }
+        }
+      }
+    },
+    "Info": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Информация"
+          }
+        }
+      }
+    },
+    "Input Monitoring": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Мониторинг ввода"
+          }
+        }
+      }
+    },
+    "Last Intercepted Action": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Последнее обработанное действие"
+          }
+        }
+      }
+    },
+    "Last normal window": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Последнее обычное окно"
+          }
+        }
+      }
+    },
+    "Last window closed via Cmd+W": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Последнее окно закрыто через Cmd+W"
+          }
+        }
+      }
+    },
+    "Launch at login": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Запускать при входе"
+          }
+        }
+      }
+    },
+    "Missing": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нет разрешения"
+          }
+        }
+      }
+    },
+    "Multiple windows open": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыто несколько окон"
+          }
+        }
+      }
+    },
+    "Needed to inspect windows and confirm the red close button safely.": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Требуется, чтобы проверять окна и безопасно распознавать красную кнопку закрытия."
+          }
+        }
+      }
+    },
+    "Needed to receive global close-button clicks before macOS handles them.": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Требуется, чтобы получать глобальные нажатия кнопки закрытия до их обработки macOS."
+          }
+        }
+      }
+    },
+    "Needs relaunch": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Требуется перезапуск"
+          }
+        }
+      }
+    },
+    "No confident normal window before Cmd+W": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перед Cmd+W не найдено достоверно определённое обычное окно"
+          }
+        }
+      }
+    },
+    "No countable windows": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нет учитываемых окон"
+          }
+        }
+      }
+    },
+    "No per-app rules": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нет правил для приложений"
+          }
+        }
+      }
+    },
+    "No recent activity yet. SmartClose only logs interception decisions after both permissions are granted and the app is enabled.": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пока нет недавней активности. SmartClose записывает решения об обработке только после предоставления обоих разрешений и включения приложения."
+          }
+        }
+      }
+    },
+    "None": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нет"
+          }
+        }
+      }
+    },
+    "Off by default. When on, SmartClose lets the app handle Cmd+W normally first, then quits it only if that closed its last normal window. Honors the ignore/allow lists and per-app rules.": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "По умолчанию отключено. Когда включено, SmartClose сначала позволяет приложению штатно обработать Cmd+W, а затем завершает его только в том случае, если было закрыто последнее обычное окно. Учитывает списки разрешений и исключений, а также правила для приложений."
+          }
+        }
+      }
+    },
+    "Open Settings": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть настройки"
+          }
+        }
+      }
+    },
+    "Pass through": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пропустить"
+          }
+        }
+      }
+    },
+    "Passed through": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пропущено"
+          }
+        }
+      }
+    },
+    "Passed through (Cmd+W)": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пропущено (Cmd+W)"
+          }
+        }
+      }
+    },
+    "Pause for 1 hour": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Приостановить на 1 час"
+          }
+        }
+      }
+    },
+    "Paused": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Приостановлено"
+          }
+        }
+      }
+    },
+    "Per-App Rules": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Правила для приложений"
+          }
+        }
+      }
+    },
+    "Permission Health": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Состояние разрешений"
+          }
+        }
+      }
+    },
+    "Policy": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Политика"
+          }
+        }
+      }
+    },
+    "Quick Setup": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Быстрая настройка"
+          }
+        }
+      }
+    },
+    "Quit SmartClose": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Завершить SmartClose"
+          }
+        }
+      }
+    },
+    "Quit request failed": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось запросить завершение"
+          }
+        }
+      }
+    },
+    "Quit request failed (Cmd+W)": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось запросить завершение (Cmd+W)"
+          }
+        }
+      }
+    },
+    "Reason: %@": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Причина: %@"
+          }
+        }
+      }
+    },
+    "Relaunch SmartClose": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перезапустить SmartClose"
+          }
+        }
+      }
+    },
+    "Relaunch SmartClose to reattach its event monitor.": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перезапустите SmartClose, чтобы повторно подключить монитор событий."
+          }
+        }
+      }
+    },
+    "Relaunch SmartClose to rebuild the global event tap.": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перезапустите SmartClose, чтобы пересоздать глобальный перехватчик событий."
+          }
+        }
+      }
+    },
+    "Remove": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удалить"
+          }
+        }
+      }
+    },
+    "Request quit": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Запросить завершение"
+          }
+        }
+      }
+    },
+    "Requested quit": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Запрошено завершение"
+          }
+        }
+      }
+    },
+    "Requested quit (Cmd+W)": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Запрошено завершение (Cmd+W)"
+          }
+        }
+      }
+    },
+    "Required Access": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Необходимый доступ"
+          }
+        }
+      }
+    },
+    "Resume SmartClose": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Возобновить SmartClose"
+          }
+        }
+      }
+    },
+    "Running": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Работает"
+          }
+        }
+      }
+    },
+    "Settings Backup": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Резервная копия настроек"
+          }
+        }
+      }
+    },
+    "Show Diagnostics": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показать диагностику"
+          }
+        }
+      }
+    },
+    "Show menu bar icon": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показывать значок в строке меню"
+          }
+        }
+      }
+    },
+    "Smart close (quit on last window)": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Умное закрытие (завершать при последнем окне)"
+          }
+        }
+      }
+    },
+    "SmartClose Diagnostics": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Диагностика SmartClose"
+          }
+        }
+      }
+    },
+    "SmartClose Settings": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Настройки SmartClose"
+          }
+        }
+      }
+    },
+    "SmartClose can inspect windows.": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SmartClose может проверять окна."
+          }
+        }
+      }
+    },
+    "SmartClose can monitor close-button clicks.": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SmartClose может отслеживать нажатия кнопки закрытия."
+          }
+        }
+      }
+    },
+    "SmartClose disabled": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SmartClose отключён"
+          }
+        }
+      }
+    },
+    "SmartClose is disabled.": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SmartClose отключён."
+          }
+        }
+      }
+    },
+    "SmartClose is ready. You can manage rules, diagnostics, and permissions anytime from the menu bar.": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SmartClose готов. Правилами, диагностикой и разрешениями можно управлять в любое время через строку меню."
+          }
+        }
+      }
+    },
+    "SmartClose needs this before it can inspect windows.": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Для проверки окон SmartClose требуется это разрешение."
+          }
+        }
+      }
+    },
+    "SmartClose needs this before it can monitor close-button clicks.": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Для отслеживания нажатий кнопки закрытия SmartClose требуется это разрешение."
+          }
+        }
+      }
+    },
+    "SmartClose needs two permissions": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SmartClose нужны два разрешения"
+          }
+        }
+      }
+    },
+    "SmartClose only becomes active once both permissions are green and the app is enabled.": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SmartClose активируется только после предоставления обоих разрешений (зелёный статус) и включения приложения."
+          }
+        }
+      }
+    },
+    "Start SmartClose at login": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Запускать SmartClose при входе"
+          }
+        }
+      }
+    },
+    "Status: %@": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Статус: %@"
+          }
+        }
+      }
+    },
+    "Status: Unknown": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Статус: неизвестен"
+          }
+        }
+      }
+    },
+    "These defaults are safe to change later in Settings.": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Эти настройки по умолчанию можно безопасно изменить позже."
+          }
+        }
+      }
+    },
+    "Unknown": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Неизвестно"
+          }
+        }
+      }
+    },
+    "Use * as a wildcard in bundle IDs (case-sensitive).": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Используйте * как подстановочный знак в идентификаторах пакетов (с учётом регистра)."
+          }
+        }
+      }
+    },
+    "Use allow list (only apply to listed apps)": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Использовать список разрешённых (применять только к указанным приложениям)"
+          }
+        }
+      }
+    },
+    "Verbose": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подробный"
+          }
+        }
+      }
+    },
+    "Waiting for macOS": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ожидание macOS"
+          }
+        }
+      }
+    },
+    "Welcome to SmartClose": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Добро пожаловать в SmartClose"
+          }
+        }
+      }
+    },
+    "Window count unavailable": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось получить число окон"
+          }
+        }
+      }
+    },
+    "Window count: %@": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Количество окон: %@"
+          }
+        }
+      }
+    },
+    "Window still open after Cmd+W": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Окно всё ещё открыто после Cmd+W"
+          }
+        }
+      }
+    },
+    "com.apple.finder": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "com.apple.finder"
+          }
+        }
+      }
+    },
+    "com.example.app": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "com.example.app"
+          }
+        }
+      }
+    },
+    "macOS did not allow SmartClose to create its global event tap.": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS не разрешила SmartClose создать глобальный перехватчик событий."
+          }
+        }
+      }
+    },
+    "macOS granted access, but SmartClose needs a relaunch to rebuild its event monitor.": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS предоставила доступ, но SmartClose нужно перезапустить, чтобы пересоздать монитор событий."
+          }
+        }
+      }
+    },
+    "macOS granted access, but SmartClose needs a relaunch to restart event monitoring.": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS предоставила доступ, но SmartClose нужно перезапустить, чтобы возобновить мониторинг событий."
+          }
+        }
+      }
+    },
+    "macOS granted access, but SmartClose needs a relaunch to start monitoring.": {
+      "localizations": {
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS предоставила доступ, но SmartClose нужно перезапустить, чтобы начать мониторинг."
+          }
+        }
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/SmartCloseApp/Settings/SettingsView.swift
+++ b/SmartCloseApp/Settings/SettingsView.swift
@@ -106,14 +106,14 @@ struct SettingsView: View {
                 Toggle("Use allow list (only apply to listed apps)", isOn: settingsStore.binding(for: \.useAllowList))
 
                 EditableStringList(
-                    title: "Allow List",
-                    placeholder: "com.example.app",
+                    title: String(localized: "Allow List"),
+                    placeholder: String(localized: "com.example.app"),
                     items: settingsStore.binding(for: \.allowedBundleIDs)
                 )
 
                 EditableStringList(
-                    title: "Ignore List",
-                    placeholder: "com.apple.finder",
+                    title: String(localized: "Ignore List"),
+                    placeholder: String(localized: "com.apple.finder"),
                     items: settingsStore.binding(for: \.ignoredBundleIDs)
                 )
 

--- a/SmartCloseTests/DecisionEngineTests.swift
+++ b/SmartCloseTests/DecisionEngineTests.swift
@@ -87,6 +87,15 @@ final class DecisionEngineTests: XCTestCase {
     func testCmdWPassesThroughWhenWindowStillOpen() {
         XCTAssertEqual(decideCmdW(before: windowCount(1), after: windowCount(1)).action, .passThrough)
         XCTAssertEqual(decideCmdW(before: windowCount(1), after: windowCount(2)).action, .passThrough)
+        XCTAssertEqual(decideCmdW(before: windowCount(2), after: windowCount(1)).action, .passThrough)
+    }
+
+    // Regression for issue #10: during rapid Cmd+W presses, Accessibility can still report the
+    // penultimate Terminal window before the final keypress. A positive, confident pre-close
+    // count must therefore remain armed; zero after verification is the only quit trigger.
+    func testCmdWQuitsAfterRapidMultiWindowSequenceReachesZero() {
+        XCTAssertEqual(decideCmdW(before: windowCount(2), after: windowCount(0)).action, .requestQuit)
+        XCTAssertEqual(decideCmdW(before: windowCount(3), after: windowCount(0, ambiguous: true)).action, .requestQuit)
     }
 
     func testCmdWCanQuitAfterTransientNonZeroRetrySample() {
@@ -124,9 +133,7 @@ final class DecisionEngineTests: XCTestCase {
         XCTAssertNil(policy.nextDelay(afterElapsed: 1.5, latestResult: windowCount(1)))
     }
 
-    func testCmdWNotArmedUnlessExactlyOneConfidentWindowBefore() {
-        // Multiple windows before → Cmd+W only closed a secondary window; never quit.
-        XCTAssertEqual(decideCmdW(before: windowCount(2), after: windowCount(0)).action, .passThrough)
+    func testCmdWRequiresAConfidentPositiveWindowCountBefore() {
         // No window before → nothing to close.
         XCTAssertEqual(decideCmdW(before: windowCount(0), after: windowCount(0)).action, .passThrough)
         // Ambiguous before → not confident there was a single normal window.

--- a/SmartCloseTests/SettingsCodableTests.swift
+++ b/SmartCloseTests/SettingsCodableTests.swift
@@ -67,3 +67,29 @@ final class SettingsCodableTests: XCTestCase {
         XCTAssertTrue(decoded.cmdWPerApp.isEmpty)
     }
 }
+
+final class LocalizationTests: XCTestCase {
+    func testRussianLocalizationIsBundledAndResolvesCoreInterfaceStrings() throws {
+        let testBundle = Bundle(for: LocalizationTests.self)
+        let hostBundleURL = testBundle.bundleURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let hostBundle = try XCTUnwrap(Bundle(url: hostBundleURL))
+        let russianURL = try XCTUnwrap(hostBundle.url(forResource: "ru", withExtension: "lproj"))
+        let russianBundle = try XCTUnwrap(Bundle(url: russianURL))
+
+        XCTAssertEqual(
+            russianBundle.localizedString(forKey: "SmartClose Settings", value: nil, table: nil),
+            "Настройки SmartClose"
+        )
+        XCTAssertEqual(
+            russianBundle.localizedString(forKey: "Handle Cmd+W (experimental)", value: nil, table: nil),
+            "Обрабатывать Cmd+W (экспериментально)"
+        )
+        XCTAssertEqual(
+            russianBundle.localizedString(forKey: "Grant Access", value: nil, table: nil),
+            "Предоставить доступ"
+        )
+    }
+}

--- a/SmartCloseUITests/SmartCloseUITests.swift
+++ b/SmartCloseUITests/SmartCloseUITests.swift
@@ -33,11 +33,22 @@ final class SmartCloseUITests: XCTestCase {
         XCTAssertTrue(app.checkBoxes["Enable SmartClose"].exists)
     }
 
-    private func launchApp(accessibility: String, inputMonitoring: String) -> XCUIApplication {
+    func testRussianLocalizationRendersOnboarding() {
+        let app = launchApp(accessibility: "missing", inputMonitoring: "missing", language: "ru")
+
+        XCTAssertTrue(app.staticTexts["SmartClose нужны два разрешения"].waitForExistence(timeout: 2))
+        XCTAssertEqual(app.buttons.matching(identifier: "Предоставить доступ").count, 2)
+        XCTAssertTrue(app.buttons["Продолжить"].exists)
+    }
+
+    private func launchApp(accessibility: String, inputMonitoring: String, language: String? = nil) -> XCUIApplication {
         let app = XCUIApplication()
         app.launchEnvironment["SMARTCLOSE_TEST_USER_DEFAULTS_SUITE"] = "SmartCloseUITests.\(UUID().uuidString)"
         app.launchEnvironment["SMARTCLOSE_TEST_ACCESSIBILITY"] = accessibility
         app.launchEnvironment["SMARTCLOSE_TEST_INPUT_MONITORING"] = inputMonitoring
+        if let language {
+            app.launchArguments += ["-AppleLanguages", "(\(language))", "-AppleLocale", "\(language)_RU"]
+        }
         app.launch()
         return app
     }

--- a/docs/release.md
+++ b/docs/release.md
@@ -99,7 +99,7 @@ Release artifacts are written to `dist/<version>/`:
 - Finder excluded.
 - Chrome with multiple windows.
 - VS Code with multiple windows.
-- Terminal excluded by default.
+- Terminal with multiple windows, including rapid consecutive Cmd+W closes when experimental Cmd+W handling is enabled.
 - Settings import/export works.
 - Pause mode works.
 - Launch at login works.


### PR DESCRIPTION
## Summary

- fix the rapid multi-window Cmd+W race reported in #10
- add a complete Russian interface requested in #14
- prepare SmartClose 0.4.0 (build 8) and update release documentation

## Root cause

SmartClose previously armed post-Cmd+W verification only when Accessibility reported exactly one normal window before the keypress. During rapid Terminal closes, macOS can briefly retain the penultimate closed window, so the final Cmd+W may still observe a stale count greater than one and skip verification.

Verification now arms for any confident positive pre-close count. The safety boundary is unchanged: SmartClose requests a normal quit only after the bounded post-close verification reaches zero windows.

## Localization

The Russian catalog covers onboarding, Settings, menu bar actions, permission and recovery states, diagnostics, app rules, file panels, policies, decisions, and recovery messages. Dynamic AppKit strings use localized lookups in addition to SwiftUI's catalog extraction.

## Validation

- Debug application build succeeded
- Release application build succeeded (universal arm64 + x86_64)
- bundle metadata verified as 0.4.0 (8)
- compiled bundle contains English and Russian localizations
- all 140 compiler-extracted localization keys match the catalog; all 139 non-empty keys have Russian translations
- regression tests added for stale positive pre-close counts followed by zero
- unit-test bundle compiled locally; execution was blocked by the workstation's macOS XCTest automation authorization modal, so the clean GitHub Actions runner is the runtime test gate

Addresses #10 and #14.
