### PR TITLE
Publish SmartClose 0.4.0 appcast

### DIFF
--- a/appcast.xml
+++ b/appcast.xml
@@ -3,12 +3,12 @@
     <channel>
         <title>SmartClose</title>
         <item>
-            <title>0.3.4</title>
-            <pubDate>Fri, 17 Jul 2026 05:28:06 +0300</pubDate>
-            <sparkle:version>7</sparkle:version>
-            <sparkle:shortVersionString>0.3.4</sparkle:shortVersionString>
+            <title>0.4.0</title>
+            <pubDate>Tue, 04 Aug 2026 15:20:47 +0300</pubDate>
+            <sparkle:version>8</sparkle:version>
+            <sparkle:shortVersionString>0.4.0</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
-            <enclosure url="https://github.com/mahirozdin/SmartClose/releases/download/v0.3.4/SmartClose-0.3.4.zip" length="2190277" type="application/octet-stream" sparkle:edSignature="kE00HrwyPuq4g1tvp41An6Sf5cJvv34af+CbYs0ui/7CpW/KQz7fk5LpQpNbwVN7L+YURxn+4RoqhRwWKtQOCQ=="/>
+            <enclosure url="https://github.com/mahirozdin/SmartClose/releases/download/v0.4.0/SmartClose-0.4.0.zip" length="2203743" type="application/octet-stream" sparkle:edSignature="A4SgGgcvgeGJ2C/sI9a2KIu4wmL/gtSHg+A037s2Ul+dL7mnigwAu9fvwCZSiM9t/xICZ/F82jIA9JAmsYWXBQ=="/>
         </item>
     </channel>
 </rss>


### PR DESCRIPTION
## Summary

- publish the Sparkle appcast entry for SmartClose 0.4.0 (build 8)
- point automatic updates at the notarized v0.4.0 ZIP release asset
- include the generated EdDSA signature and exact enclosure length

## Validation

- GitHub Release v0.4.0 is published with ZIP, DMG, and SHA-256 assets
- ZIP and DMG checksums pass
- exported, zipped, and DMG-contained apps pass Developer ID signature, notarization ticket, and Gatekeeper checks
- appcast XML is well formed
- appcast enclosure length matches the published ZIP size (2,203,743 bytes)
